### PR TITLE
Enable LTO for release builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2433,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ default-members = ["proxelar-cli"]
 
 [workspace.package]
 rust-version = "1.94"
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
## Summary
- add a workspace-level release profile
- enable LTO and set codegen-units to 1 for optimized builds
- keep development builds unchanged

## Verification
- cargo build --release --workspace
- cargo test --workspace (fails in sandbox on proxyapi/tests/forward_proxy.rs with PermissionDenied while binding a local listener)

Closes #122