### PR TITLE
fix: stream large bodies without bypassing hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 
+- Add a configurable body capture limit so large uploads/downloads stream safely while preserving intercept, replay, and Lua hook behavior.
 - Dependency updates: rand 0.10.1, actions/upload-pages-artifact 5, softprops/action-gh-release 3
 - Replace CLAUDE.md with compact AGENTS.md contributor instructions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## [Unreleased]
 
-- Add a configurable body capture limit so large uploads/downloads stream safely while preserving intercept, replay, and Lua hook behavior.
+- Add an optional body capture limit so large uploads/downloads can stream safely while preserving the default unlimited capture behavior.
 - Dependency updates: rand 0.10.1, actions/upload-pages-artifact 5, softprops/action-gh-release 3
 - Replace CLAUDE.md with compact AGENTS.md contributor instructions
 

--- a/proxelar-cli/src/cli.rs
+++ b/proxelar-cli/src/cli.rs
@@ -40,6 +40,14 @@ pub struct Args {
     /// Path to a Lua script for request/response hooks
     #[arg(short = 's', long = "script", value_name = "FILE")]
     pub script: Option<PathBuf>,
+
+    /// Maximum body bytes buffered for capture/editing before passthrough
+    #[arg(
+        long = "body-capture-limit",
+        value_name = "BYTES",
+        default_value_t = proxyapi::DEFAULT_BODY_CAPTURE_LIMIT
+    )]
+    pub body_capture_limit: usize,
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -65,6 +73,10 @@ mod tests {
         assert!(matches!(args.interface, Interface::Tui));
         assert!(matches!(args.mode, Mode::Forward));
         assert_eq!(args.port, 8080);
+        assert_eq!(
+            args.body_capture_limit,
+            proxyapi::DEFAULT_BODY_CAPTURE_LIMIT
+        );
     }
 
     #[test]
@@ -78,5 +90,12 @@ mod tests {
         let args = Args::parse_from(["proxelar", "-i", "gui", "--gui-port", "9090"]);
         assert!(matches!(args.interface, Interface::Gui));
         assert_eq!(args.gui_port, 9090);
+    }
+
+    #[test]
+    fn test_body_capture_limit_arg() {
+        let args = Args::parse_from(["proxelar", "--body-capture-limit", "4096"]);
+
+        assert_eq!(args.body_capture_limit, 4096);
     }
 }

--- a/proxelar-cli/src/cli.rs
+++ b/proxelar-cli/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, ValueEnum};
 use std::net::IpAddr;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 #[derive(Parser)]
 #[command(
@@ -41,13 +42,43 @@ pub struct Args {
     #[arg(short = 's', long = "script", value_name = "FILE")]
     pub script: Option<PathBuf>,
 
-    /// Maximum body bytes buffered for capture/editing before passthrough
+    /// Maximum body bytes buffered for capture/editing before passthrough (`free` for unlimited)
     #[arg(
         long = "body-capture-limit",
-        value_name = "BYTES",
-        default_value_t = proxyapi::DEFAULT_BODY_CAPTURE_LIMIT
+        value_name = "BYTES|free",
+        default_value = "free"
     )]
-    pub body_capture_limit: usize,
+    pub body_capture_limit: BodyCaptureLimit,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BodyCaptureLimit {
+    Unlimited,
+    Bytes(usize),
+}
+
+impl BodyCaptureLimit {
+    pub fn into_option(self) -> Option<usize> {
+        match self {
+            Self::Unlimited => None,
+            Self::Bytes(bytes) => Some(bytes),
+        }
+    }
+}
+
+impl FromStr for BodyCaptureLimit {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim();
+        match value.to_ascii_lowercase().as_str() {
+            "free" | "unlimited" | "none" => Ok(Self::Unlimited),
+            _ => value
+                .parse()
+                .map(Self::Bytes)
+                .map_err(|_| "expected a byte count, `free`, `unlimited`, or `none`".to_owned()),
+        }
+    }
 }
 
 #[derive(Clone, Debug, ValueEnum)]
@@ -74,7 +105,7 @@ mod tests {
         assert!(matches!(args.mode, Mode::Forward));
         assert_eq!(args.port, 8080);
         assert_eq!(
-            args.body_capture_limit,
+            args.body_capture_limit.into_option(),
             proxyapi::DEFAULT_BODY_CAPTURE_LIMIT
         );
     }
@@ -96,6 +127,13 @@ mod tests {
     fn test_body_capture_limit_arg() {
         let args = Args::parse_from(["proxelar", "--body-capture-limit", "4096"]);
 
-        assert_eq!(args.body_capture_limit, 4096);
+        assert_eq!(args.body_capture_limit, BodyCaptureLimit::Bytes(4096));
+    }
+
+    #[test]
+    fn test_body_capture_limit_free_arg() {
+        let args = Args::parse_from(["proxelar", "--body-capture-limit", "free"]);
+
+        assert_eq!(args.body_capture_limit, BodyCaptureLimit::Unlimited);
     }
 }

--- a/proxelar-cli/src/main.rs
+++ b/proxelar-cli/src/main.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_tx,
         ca_dir,
         intercept: Some(Arc::clone(&intercept)),
-        body_capture_limit: args.body_capture_limit,
+        body_capture_limit: args.body_capture_limit.into_option(),
         #[cfg(feature = "scripting")]
         script_path: args.script,
         replay_rx: Some(replay_rx),

--- a/proxelar-cli/src/main.rs
+++ b/proxelar-cli/src/main.rs
@@ -14,9 +14,7 @@ const EVENT_CHANNEL_CAPACITY: usize = 10_000;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    rustls::crypto::ring::default_provider()
-        .install_default()
-        .map_err(|e| format!("Failed to install rustls crypto provider: {e:?}"))?;
+    let _ = rustls::crypto::ring::default_provider().install_default();
 
     let args = Args::parse();
     tracing_subscriber::fmt()
@@ -57,6 +55,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         event_tx,
         ca_dir,
         intercept: Some(Arc::clone(&intercept)),
+        body_capture_limit: args.body_capture_limit,
         #[cfg(feature = "scripting")]
         script_path: args.script,
         replay_rx: Some(replay_rx),

--- a/proxyapi/src/body.rs
+++ b/proxyapi/src/body.rs
@@ -15,7 +15,7 @@ pub type ProxyBody = BoxBody<Bytes, hyper::Error>;
 #[derive(Clone, Debug)]
 pub(crate) struct BodyCapture {
     inner: Arc<Mutex<BodyCaptureState>>,
-    limit: usize,
+    limit: Option<usize>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -33,7 +33,7 @@ struct BodyCaptureState {
 }
 
 impl BodyCapture {
-    pub(crate) fn new(limit: usize) -> Self {
+    pub(crate) fn new(limit: Option<usize>) -> Self {
         Self {
             inner: Arc::new(Mutex::new(BodyCaptureState {
                 bytes: BytesMut::new(),
@@ -48,13 +48,17 @@ impl BodyCapture {
         let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
         state.total_seen = state.total_seen.saturating_add(chunk.len());
 
-        let remaining = self.limit.saturating_sub(state.bytes.len());
-        if remaining > 0 {
-            let keep = remaining.min(chunk.len());
-            state.bytes.extend_from_slice(&chunk[..keep]);
-        }
-        if chunk.len() > remaining {
-            state.truncated = true;
+        if let Some(limit) = self.limit {
+            let remaining = limit.saturating_sub(state.bytes.len());
+            if remaining > 0 {
+                let keep = remaining.min(chunk.len());
+                state.bytes.extend_from_slice(&chunk[..keep]);
+            }
+            if chunk.len() > remaining {
+                state.truncated = true;
+            }
+        } else {
+            state.bytes.extend_from_slice(chunk);
         }
     }
 
@@ -265,7 +269,7 @@ mod tests {
 
     #[tokio::test]
     async fn capture_body_forwards_all_bytes_and_caps_snapshot() {
-        let capture_state = BodyCapture::new(4);
+        let capture_state = BodyCapture::new(Some(4));
         let body = capture(
             full(Bytes::from_static(b"abcdef")),
             capture_state.clone(),
@@ -282,12 +286,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn capture_body_keeps_full_snapshot_when_unlimited() {
+        let capture_state = BodyCapture::new(None);
+        let body = capture(
+            full(Bytes::from_static(b"abcdef")),
+            capture_state.clone(),
+            || {},
+        );
+
+        let collected = body.collect().await.unwrap().to_bytes();
+        let snapshot = capture_state.snapshot();
+
+        assert_eq!(collected.as_ref(), b"abcdef");
+        assert_eq!(snapshot.bytes.as_ref(), b"abcdef");
+        assert!(!snapshot.truncated);
+        assert_eq!(snapshot.total_seen, 6);
+    }
+
+    #[tokio::test]
     async fn capture_body_runs_completion_once_at_end_of_stream() {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         let completed = Arc::new(AtomicUsize::new(0));
         let completed_for_body = Arc::clone(&completed);
-        let body = capture(full(Bytes::new()), BodyCapture::new(16), move || {
+        let body = capture(full(Bytes::new()), BodyCapture::new(Some(16)), move || {
             completed_for_body.fetch_add(1, Ordering::SeqCst);
         });
 
@@ -305,7 +327,7 @@ mod tests {
         let completed_for_body = Arc::clone(&completed);
         let body = capture(
             full(Bytes::from_static(b"body")),
-            BodyCapture::new(16),
+            BodyCapture::new(Some(16)),
             move || {
                 completed_for_body.fetch_add(1, Ordering::SeqCst);
             },

--- a/proxyapi/src/body.rs
+++ b/proxyapi/src/body.rs
@@ -1,11 +1,235 @@
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use http_body_util::{combinators::BoxBody, BodyExt, Empty, Full};
+use hyper::body::{Body as HttpBody, Frame, SizeHint};
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
 
 /// Boxed HTTP body type used throughout the proxy.
 ///
 /// Erases the concrete body type so that both `Full` (captured) and `Empty`
 /// bodies can be returned in the same position.
 pub type ProxyBody = BoxBody<Bytes, hyper::Error>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct BodyCapture {
+    inner: Arc<Mutex<BodyCaptureState>>,
+    limit: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BodySnapshot {
+    pub bytes: Bytes,
+    pub truncated: bool,
+    pub total_seen: usize,
+}
+
+#[derive(Debug)]
+struct BodyCaptureState {
+    bytes: BytesMut,
+    truncated: bool,
+    total_seen: usize,
+}
+
+impl BodyCapture {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(BodyCaptureState {
+                bytes: BytesMut::new(),
+                truncated: false,
+                total_seen: 0,
+            })),
+            limit,
+        }
+    }
+
+    pub(crate) fn append(&self, chunk: &Bytes) {
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        state.total_seen = state.total_seen.saturating_add(chunk.len());
+
+        let remaining = self.limit.saturating_sub(state.bytes.len());
+        if remaining > 0 {
+            let keep = remaining.min(chunk.len());
+            state.bytes.extend_from_slice(&chunk[..keep]);
+        }
+        if chunk.len() > remaining {
+            state.truncated = true;
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> BodySnapshot {
+        let state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        BodySnapshot {
+            bytes: Bytes::copy_from_slice(&state.bytes),
+            truncated: state.truncated,
+            total_seen: state.total_seen,
+        }
+    }
+}
+
+struct CaptureBody<B, F: FnOnce()> {
+    inner: Pin<Box<B>>,
+    capture: BodyCapture,
+    on_complete: Option<F>,
+}
+
+impl<B, F> CaptureBody<B, F>
+where
+    F: FnOnce(),
+{
+    fn new(body: B, capture: BodyCapture, on_complete: F) -> Self {
+        Self {
+            inner: Box::pin(body),
+            capture,
+            on_complete: Some(on_complete),
+        }
+    }
+}
+
+impl<B, F> CaptureBody<B, F>
+where
+    F: FnOnce(),
+{
+    fn complete(&mut self) {
+        if let Some(on_complete) = self.on_complete.take() {
+            on_complete();
+        }
+    }
+}
+
+impl<B, F> Unpin for CaptureBody<B, F> where F: FnOnce() {}
+
+impl<B, F> HttpBody for CaptureBody<B, F>
+where
+    B: HttpBody<Data = Bytes, Error = hyper::Error>,
+    F: FnOnce(),
+{
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(data) = frame.data_ref() {
+                    this.capture.append(data);
+                }
+                if this.inner.is_end_stream() {
+                    this.complete();
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(None) => {
+                this.complete();
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(e))) => {
+                this.complete();
+                Poll::Ready(Some(Err(e)))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+impl<B, F> Drop for CaptureBody<B, F>
+where
+    F: FnOnce(),
+{
+    fn drop(&mut self) {
+        self.complete();
+    }
+}
+
+pub(crate) fn capture<B, F>(body: B, capture: BodyCapture, on_complete: F) -> ProxyBody
+where
+    B: HttpBody<Data = Bytes, Error = hyper::Error> + Send + Sync + 'static,
+    F: FnOnce() + Send + Sync + 'static,
+{
+    CaptureBody::new(body, capture, on_complete).boxed()
+}
+
+struct PrefixBody<B> {
+    prefixes: VecDeque<Bytes>,
+    inner: Pin<Box<B>>,
+}
+
+impl<B> PrefixBody<B> {
+    fn new<I>(prefixes: I, body: B) -> Self
+    where
+        I: IntoIterator<Item = Bytes>,
+    {
+        Self {
+            prefixes: prefixes
+                .into_iter()
+                .filter(|bytes| !bytes.is_empty())
+                .collect(),
+            inner: Box::pin(body),
+        }
+    }
+}
+
+impl<B> Unpin for PrefixBody<B> {}
+
+impl<B> HttpBody for PrefixBody<B>
+where
+    B: HttpBody<Data = Bytes, Error = hyper::Error>,
+{
+    type Data = Bytes;
+    type Error = hyper::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        if let Some(prefix) = this.prefixes.pop_front() {
+            return Poll::Ready(Some(Ok(Frame::data(prefix))));
+        }
+
+        this.inner.as_mut().poll_frame(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.prefixes.is_empty() && self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        let mut hint = self.inner.size_hint();
+        let prefix_len = self
+            .prefixes
+            .iter()
+            .fold(0_u64, |acc, bytes| acc.saturating_add(bytes.len() as u64));
+
+        let lower = hint.lower().saturating_add(prefix_len);
+        if let Some(upper) = hint.upper() {
+            hint.set_upper(upper.saturating_add(prefix_len));
+        }
+        hint.set_lower(lower);
+
+        hint
+    }
+}
+
+pub(crate) fn prefix<B, I>(prefixes: I, body: B) -> ProxyBody
+where
+    B: HttpBody<Data = Bytes, Error = hyper::Error> + Send + Sync + 'static,
+    I: IntoIterator<Item = Bytes>,
+{
+    PrefixBody::new(prefixes, body).boxed()
+}
 
 /// Create a body from the given bytes.
 pub fn full(bytes: Bytes) -> ProxyBody {
@@ -37,5 +261,74 @@ mod tests {
         let body = empty();
         let collected = body.collect().await.unwrap().to_bytes();
         assert!(collected.is_empty());
+    }
+
+    #[tokio::test]
+    async fn capture_body_forwards_all_bytes_and_caps_snapshot() {
+        let capture_state = BodyCapture::new(4);
+        let body = capture(
+            full(Bytes::from_static(b"abcdef")),
+            capture_state.clone(),
+            || {},
+        );
+
+        let collected = body.collect().await.unwrap().to_bytes();
+        let snapshot = capture_state.snapshot();
+
+        assert_eq!(collected.as_ref(), b"abcdef");
+        assert_eq!(snapshot.bytes.as_ref(), b"abcd");
+        assert!(snapshot.truncated);
+        assert_eq!(snapshot.total_seen, 6);
+    }
+
+    #[tokio::test]
+    async fn capture_body_runs_completion_once_at_end_of_stream() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let completed = Arc::new(AtomicUsize::new(0));
+        let completed_for_body = Arc::clone(&completed);
+        let body = capture(full(Bytes::new()), BodyCapture::new(16), move || {
+            completed_for_body.fetch_add(1, Ordering::SeqCst);
+        });
+
+        let collected = body.collect().await.unwrap().to_bytes();
+
+        assert!(collected.is_empty());
+        assert_eq!(completed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn capture_body_runs_completion_when_dropped_before_eof() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let completed = Arc::new(AtomicUsize::new(0));
+        let completed_for_body = Arc::clone(&completed);
+        let body = capture(
+            full(Bytes::from_static(b"body")),
+            BodyCapture::new(16),
+            move || {
+                completed_for_body.fetch_add(1, Ordering::SeqCst);
+            },
+        );
+
+        drop(body);
+
+        assert_eq!(completed.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn prefix_body_replays_prefixes_before_inner_body() {
+        let body = prefix(
+            [
+                Bytes::from_static(b"hello "),
+                Bytes::new(),
+                Bytes::from_static(b"from "),
+            ],
+            full(Bytes::from_static(b"inner")),
+        );
+
+        let collected = body.collect().await.unwrap().to_bytes();
+
+        assert_eq!(collected.as_ref(), b"hello from inner");
     }
 }

--- a/proxyapi/src/handler.rs
+++ b/proxyapi/src/handler.rs
@@ -1,107 +1,249 @@
 use async_trait::async_trait;
-use bytes::Bytes;
-use http_body_util::{BodyExt, Limited};
+use bytes::{Bytes, BytesMut};
+use http_body_util::BodyExt;
+use hyper::body::Body as HttpBody;
 use hyper::{Request, Response};
 use proxyapi_models::{ProxiedRequest, ProxiedResponse};
 use std::sync::Arc;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Notify};
 
-use crate::body::{self, ProxyBody};
+use crate::body::{self, BodyCapture, BodySnapshot, ProxyBody};
 use crate::event::{next_id, ProxyEvent};
 use crate::intercept::{InterceptConfig, InterceptDecision};
 use crate::{HttpContext, HttpHandler, RequestOrResponse};
 
-/// Maximum body size the proxy will collect (100 MB).
+/// Default maximum body size the proxy buffers for capture/editing (100 MB).
 ///
-/// Bodies exceeding this limit are replaced with an empty body in the
-/// captured event. The proxied traffic itself is unaffected.
-const MAX_BODY_SIZE: usize = 100 * 1024 * 1024;
+/// Larger bodies are streamed through unchanged when possible, with stored
+/// captures capped at this size.
+pub const DEFAULT_BODY_CAPTURE_LIMIT: usize = 100 * 1024 * 1024;
+
+enum BodyCollection {
+    Complete(Bytes),
+    Exceeded { captured: Bytes, body: ProxyBody },
+}
+
+enum RequestBody {
+    Buffered(Bytes),
+    Streaming { captured: Bytes, body: ProxyBody },
+}
+
+impl RequestBody {
+    fn hook_bytes(&self) -> &Bytes {
+        match self {
+            Self::Buffered(bytes)
+            | Self::Streaming {
+                captured: bytes, ..
+            } => bytes,
+        }
+    }
+
+    fn apply_modified_body(&mut self, original_hook_body: &Bytes, modified_body: Bytes) {
+        if matches!(self, Self::Streaming { .. }) && modified_body == *original_hook_body {
+            return;
+        }
+
+        *self = Self::Buffered(modified_body);
+    }
+}
 
 pub(crate) fn now_millis() -> i64 {
     chrono::Local::now().timestamp_millis()
 }
 
-/// Collect the response body, emit a [`ProxyEvent`], and return the reconstructed response.
-///
-/// This is the single source of truth for response capture, used by both
-/// forward and reverse proxy paths. When scripting is enabled, the Lua
-/// `on_response` hook is called here before building the final response.
-pub fn collect_and_emit(
-    handler: &mut CapturingHandler,
-    #[allow(unused_mut)] mut parts: http::response::Parts,
-    #[allow(unused_mut)] mut body_bytes: Bytes,
-) -> Response<ProxyBody> {
-    // Run Lua on_response hook (if scripting is enabled and a script is loaded).
-    #[cfg(feature = "scripting")]
-    if let Some(ref engine) = handler.script_engine {
-        let (req_method, req_url) = handler
-            .captured_request
-            .as_ref()
-            .map(|r| (r.method().as_str().to_owned(), r.uri().to_string()))
-            .unwrap_or_default();
+#[derive(Clone)]
+enum CapturedRequest {
+    Buffered(ProxiedRequest),
+    Streaming {
+        method: http::Method,
+        uri: http::Uri,
+        version: http::Version,
+        headers: http::HeaderMap,
+        body: BodyCapture,
+        done: Arc<Notify>,
+        time: i64,
+    },
+}
 
-        match engine.on_response(
-            &req_method,
-            &req_url,
-            parts.status.as_u16(),
-            &parts.headers,
-            &body_bytes,
-        ) {
-            Ok(crate::scripting::ScriptResponseAction::Modified {
-                status,
+impl CapturedRequest {
+    fn buffered(request: ProxiedRequest) -> Self {
+        Self::Buffered(request)
+    }
+
+    fn streaming(
+        parts: &http::request::Parts,
+        body: BodyCapture,
+        done: Arc<Notify>,
+        time: i64,
+    ) -> Self {
+        Self::Streaming {
+            method: parts.method.clone(),
+            uri: parts.uri.clone(),
+            version: parts.version,
+            headers: parts.headers.clone(),
+            body,
+            done,
+            time,
+        }
+    }
+
+    fn into_proxied_request(self) -> ProxiedRequest {
+        match self {
+            Self::Buffered(request) => request,
+            Self::Streaming {
+                method,
+                uri,
+                version,
                 headers,
                 body,
-            }) => {
-                if let Ok(s) = http::StatusCode::from_u16(status) {
-                    parts.status = s;
-                }
-                parts.headers = headers;
-                body_bytes = body;
-            }
-            Ok(crate::scripting::ScriptResponseAction::PassThrough) => {}
-            Err(e) => {
-                tracing::warn!("Lua on_response error (passing through): {e}");
+                done: _,
+                time,
+            } => {
+                let snapshot = body.snapshot();
+                log_truncated_capture("request", &snapshot);
+                ProxiedRequest::new(method, uri, version, headers, snapshot.bytes, time)
             }
         }
     }
 
-    let proxied_response = ProxiedResponse::new(
-        parts.status,
-        parts.version,
-        parts.headers.clone(),
-        body_bytes.clone(),
-        now_millis(),
-    );
-
-    if let Some(request) = handler.take_captured_request() {
-        // Use the ID assigned at the start of handle_request (intercept flow)
-        // so that RequestIntercepted and RequestComplete share the same ID.
-        // Fall back to next_id() for the normal (non-intercept) path.
-        let id = handler.pending_id.take().unwrap_or_else(next_id);
-        let event = ProxyEvent::RequestComplete {
-            id,
-            request: Box::new(request),
-            response: Box::new(proxied_response),
-        };
-        handler.send_event(event);
+    async fn into_proxied_request_after_capture(self) -> ProxiedRequest {
+        match self {
+            Self::Buffered(request) => request,
+            Self::Streaming {
+                method,
+                uri,
+                version,
+                headers,
+                body,
+                done,
+                time,
+            } => {
+                done.notified().await;
+                let snapshot = body.snapshot();
+                log_truncated_capture("request", &snapshot);
+                ProxiedRequest::new(method, uri, version, headers, snapshot.bytes, time)
+            }
+        }
     }
 
-    Response::from_parts(parts, body::full(body_bytes))
+    #[cfg(feature = "scripting")]
+    fn request_line(&self) -> (String, String) {
+        match self {
+            Self::Buffered(request) => (
+                request.method().as_str().to_owned(),
+                request.uri().to_string(),
+            ),
+            Self::Streaming { method, uri, .. } => (method.as_str().to_owned(), uri.to_string()),
+        }
+    }
 }
 
-/// Collect response body bytes up to [`MAX_BODY_SIZE`], logging a warning on failure.
-pub async fn collect_body(body: hyper::body::Incoming) -> Bytes {
-    Limited::new(body, MAX_BODY_SIZE)
-        .collect()
-        .await
-        .map(http_body_util::Collected::to_bytes)
-        .unwrap_or_else(|e| {
+fn log_truncated_capture(kind: &str, snapshot: &BodySnapshot) {
+    if snapshot.truncated {
+        tracing::warn!(
+            "Captured {kind} body truncated at {} bytes after seeing {} bytes; proxied traffic was streamed through unchanged",
+            snapshot.bytes.len(),
+            snapshot.total_seen
+        );
+    }
+}
+
+fn try_send_event(tx: &mpsc::Sender<ProxyEvent>, event: ProxyEvent) {
+    match tx.try_send(event) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            tracing::warn!("Event channel full, dropping event");
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {
+            tracing::debug!("Event channel closed");
+        }
+    }
+}
+
+fn send_request_complete(
+    tx: &mpsc::Sender<ProxyEvent>,
+    id: u64,
+    request: ProxiedRequest,
+    response: ProxiedResponse,
+) {
+    try_send_event(
+        tx,
+        ProxyEvent::RequestComplete {
+            id,
+            request: Box::new(request),
+            response: Box::new(response),
+        },
+    );
+}
+
+struct HookedResponse {
+    parts: http::response::Parts,
+    body: HookedResponseBody,
+}
+
+enum HookedResponseBody {
+    Original(Bytes),
+    #[cfg(feature = "scripting")]
+    Replaced(Bytes),
+}
+
+impl HookedResponseBody {
+    fn is_original(&self) -> bool {
+        matches!(self, Self::Original(_))
+    }
+
+    fn into_bytes(self) -> Bytes {
+        match self {
+            Self::Original(bytes) => bytes,
+            #[cfg(feature = "scripting")]
+            Self::Replaced(bytes) => bytes,
+        }
+    }
+}
+
+/// Collect body bytes for byte-editing features, up to the configured limit.
+///
+/// When the body exceeds the limit, returns a reconstructed streaming body that
+/// first replays already-read bytes, then continues the original body.
+async fn collect_body<B>(mut body: B, limit: usize, kind: &'static str) -> BodyCollection
+where
+    B: HttpBody<Data = Bytes, Error = hyper::Error> + Send + Sync + Unpin + 'static,
+{
+    let mut buffer = BytesMut::new();
+
+    while let Some(frame) = body.frame().await {
+        let frame = match frame {
+            Ok(frame) => frame,
+            Err(e) => {
+                tracing::warn!("Failed to collect {kind} body: {e}");
+                return BodyCollection::Complete(Bytes::new());
+            }
+        };
+
+        let Ok(data) = frame.into_data() else {
+            continue;
+        };
+
+        if buffer.len().saturating_add(data.len()) > limit {
             tracing::warn!(
-                "Failed to collect response body (possibly exceeds {}MB limit): {e}",
-                MAX_BODY_SIZE / (1024 * 1024)
+                "{kind} body exceeded editable limit of {limit} bytes; streaming through without body editing"
             );
-            Bytes::new()
-        })
+            let keep = limit.saturating_sub(buffer.len()).min(data.len());
+            if keep > 0 {
+                buffer.extend_from_slice(&data[..keep]);
+            }
+            let captured = buffer.freeze();
+            let overflow = data.slice(keep..);
+            return BodyCollection::Exceeded {
+                body: body::prefix([captured.clone(), overflow], body),
+                captured,
+            };
+        }
+
+        buffer.extend_from_slice(&data);
+    }
+
+    BodyCollection::Complete(buffer.freeze())
 }
 
 /// Default handler that captures request/response pairs and emits [`ProxyEvent`]s.
@@ -111,12 +253,12 @@ pub async fn collect_body(body: hyper::body::Incoming) -> Bytes {
 #[derive(Clone)]
 pub struct CapturingHandler {
     event_tx: mpsc::Sender<ProxyEvent>,
-    captured_request: Option<ProxiedRequest>,
-    /// ID assigned at the start of `handle_request`. Carried through to
-    /// `collect_and_emit` so that `RequestIntercepted` and `RequestComplete`
-    /// events share the same ID and the UI can correlate them.
+    captured_request: Option<CapturedRequest>,
+    /// ID assigned at the start of `handle_request` so that related events
+    /// share the same ID and the UI can correlate them.
     pending_id: Option<u64>,
     intercept: Option<Arc<InterceptConfig>>,
+    body_capture_limit: usize,
     #[cfg(feature = "scripting")]
     script_engine: Option<Arc<crate::scripting::ScriptEngine>>,
 }
@@ -127,6 +269,7 @@ impl std::fmt::Debug for CapturingHandler {
             .field("event_tx", &self.event_tx)
             .field("captured_request", &self.captured_request.is_some())
             .field("pending_id", &self.pending_id)
+            .field("body_capture_limit", &self.body_capture_limit)
             .finish_non_exhaustive()
     }
 }
@@ -140,9 +283,20 @@ impl CapturingHandler {
             captured_request: None,
             pending_id: None,
             intercept: None,
+            body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
             #[cfg(feature = "scripting")]
             script_engine: None,
         }
+    }
+
+    /// Set the maximum body bytes buffered for capture and byte-editing paths.
+    ///
+    /// Bodies above this limit are streamed through unchanged and captured only
+    /// up to the configured limit.
+    #[must_use]
+    pub fn with_body_capture_limit(mut self, limit: usize) -> Self {
+        self.body_capture_limit = limit;
+        self
     }
 
     /// Attach an intercept controller for interactive request/response editing.
@@ -161,11 +315,38 @@ impl CapturingHandler {
     }
 
     pub(crate) fn take_captured_request(&mut self) -> Option<ProxiedRequest> {
+        self.take_captured_request_state()
+            .map(CapturedRequest::into_proxied_request)
+    }
+
+    fn take_captured_request_state(&mut self) -> Option<CapturedRequest> {
         self.captured_request.take()
     }
 
-    /// Take the pending flow ID so the WS path can claim it before
-    /// `collect_and_emit` would use it.
+    fn should_buffer_response(&self) -> bool {
+        #[cfg(feature = "scripting")]
+        if self.script_engine.is_some() {
+            return true;
+        }
+
+        false
+    }
+
+    fn should_buffer_request(&self) -> bool {
+        if self.intercept.as_ref().is_some_and(|cfg| cfg.is_enabled()) {
+            return true;
+        }
+
+        #[cfg(feature = "scripting")]
+        if self.script_engine.is_some() {
+            return true;
+        }
+
+        false
+    }
+
+    /// Take the pending flow ID so the WS path can claim it before response
+    /// completion would use it.
     pub(crate) fn take_pending_id(&mut self) -> Option<u64> {
         self.pending_id.take()
     }
@@ -193,18 +374,22 @@ impl CapturingHandler {
         let mut headers = req.headers().clone();
         let mut body_bytes = req.body().clone();
 
-        self.captured_request = Some(ProxiedRequest::new(
+        self.captured_request = Some(CapturedRequest::buffered(ProxiedRequest::new(
             method.clone(),
             uri.clone(),
             version,
             headers.clone(),
             body_bytes.clone(),
             now_millis(),
-        ));
+        )));
 
         if let Some(ref cfg) = self.intercept {
             if cfg.is_enabled() {
-                let snapshot = self.captured_request.clone().unwrap();
+                let snapshot = self
+                    .captured_request
+                    .clone()
+                    .unwrap()
+                    .into_proxied_request();
                 let rx = cfg.register(id);
                 if self
                     .event_tx
@@ -233,14 +418,15 @@ impl CapturingHandler {
                             }
                             headers = h;
                             body_bytes = b;
-                            self.captured_request = Some(ProxiedRequest::new(
-                                method.clone(),
-                                uri.clone(),
-                                version,
-                                headers.clone(),
-                                body_bytes.clone(),
-                                now_millis(),
-                            ));
+                            self.captured_request =
+                                Some(CapturedRequest::buffered(ProxiedRequest::new(
+                                    method.clone(),
+                                    uri.clone(),
+                                    version,
+                                    headers.clone(),
+                                    body_bytes.clone(),
+                                    now_millis(),
+                                )));
                         }
                         Ok(Ok(InterceptDecision::Block { status, body })) => {
                             let status_code = http::StatusCode::from_u16(status)
@@ -250,7 +436,7 @@ impl CapturingHandler {
                                 .body(())
                                 .unwrap()
                                 .into_parts();
-                            collect_and_emit(self, parts, body);
+                            self.emit_captured_response(parts, body);
                             return None;
                         }
                         _ => {
@@ -270,13 +456,235 @@ impl CapturingHandler {
     }
 
     pub(crate) fn send_event(&self, event: ProxyEvent) {
-        match self.event_tx.try_send(event) {
-            Ok(()) => {}
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                tracing::warn!("Event channel full, dropping event");
+        try_send_event(&self.event_tx, event);
+    }
+
+    pub(crate) async fn handle_upstream_response<B>(
+        &mut self,
+        res: Response<B>,
+    ) -> Response<ProxyBody>
+    where
+        B: HttpBody<Data = Bytes, Error = hyper::Error> + Send + Sync + Unpin + 'static,
+    {
+        let (parts, body) = res.into_parts();
+        if !self.should_buffer_response() {
+            return self.stream_response(parts, body);
+        }
+
+        match collect_body(body, self.body_capture_limit, "response").await {
+            BodyCollection::Complete(body_bytes) => {
+                self.finish_buffered_response(parts, body_bytes)
             }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                tracing::debug!("Event channel closed");
+            BodyCollection::Exceeded { captured, body } => {
+                self.finish_limited_response(parts, captured, body)
+            }
+        }
+    }
+
+    pub(crate) async fn record_upstream_response<B>(&mut self, res: Response<B>)
+    where
+        B: HttpBody<Data = Bytes, Error = hyper::Error> + Send + Sync + Unpin + 'static,
+    {
+        let (parts, body) = res.into_parts();
+        match collect_body(body, self.body_capture_limit, "response").await {
+            BodyCollection::Complete(body_bytes) => self.emit_captured_response(parts, body_bytes),
+            BodyCollection::Exceeded { captured, .. } => {
+                self.emit_captured_response(parts, captured);
+            }
+        }
+    }
+
+    fn finish_buffered_response(
+        &mut self,
+        parts: http::response::Parts,
+        body_bytes: Bytes,
+    ) -> Response<ProxyBody> {
+        let hooked = self.apply_response_hook_to_snapshot(parts, body_bytes);
+        let HookedResponse { parts, body } = hooked;
+        let body_bytes = body.into_bytes();
+        self.emit_response_snapshot(&parts, body_bytes.clone());
+
+        Response::from_parts(parts, body::full(body_bytes))
+    }
+
+    fn finish_limited_response(
+        &mut self,
+        parts: http::response::Parts,
+        captured: Bytes,
+        body: ProxyBody,
+    ) -> Response<ProxyBody> {
+        let hooked = self.apply_response_hook_to_snapshot(parts, captured);
+        if hooked.body.is_original() {
+            self.stream_response(hooked.parts, body)
+        } else {
+            let HookedResponse { parts, body } = hooked;
+            let body_bytes = body.into_bytes();
+            self.emit_response_snapshot(&parts, body_bytes.clone());
+            Response::from_parts(parts, body::full(body_bytes))
+        }
+    }
+
+    fn emit_captured_response(&mut self, parts: http::response::Parts, body_bytes: Bytes) {
+        let hooked = self.apply_response_hook_to_snapshot(parts, body_bytes);
+        let HookedResponse { parts, body } = hooked;
+        self.emit_response_snapshot(&parts, body.into_bytes());
+    }
+
+    fn stream_response<B>(&mut self, parts: http::response::Parts, body: B) -> Response<ProxyBody>
+    where
+        B: HttpBody<Data = Bytes, Error = hyper::Error> + Send + Sync + 'static,
+    {
+        let status = parts.status;
+        let version = parts.version;
+        let headers = parts.headers.clone();
+        let request = self.take_captured_request_state();
+        let id = self.pending_id.take().unwrap_or_else(next_id);
+        let event_tx = self.event_tx_clone();
+        let response_capture = BodyCapture::new(self.body_capture_limit);
+        let response_capture_for_body = response_capture.clone();
+
+        let body = body::capture(body, response_capture, move || {
+            let Some(request) = request else {
+                return;
+            };
+
+            let response_snapshot = response_capture_for_body.snapshot();
+            log_truncated_capture("response", &response_snapshot);
+            let response = ProxiedResponse::new(
+                status,
+                version,
+                headers,
+                response_snapshot.bytes,
+                now_millis(),
+            );
+
+            match request {
+                CapturedRequest::Buffered(request) => {
+                    send_request_complete(&event_tx, id, request, response);
+                }
+                request => {
+                    tokio::spawn(async move {
+                        let request = request.into_proxied_request_after_capture().await;
+                        send_request_complete(&event_tx, id, request, response);
+                    });
+                }
+            }
+        });
+
+        Response::from_parts(parts, body)
+    }
+
+    #[cfg(feature = "scripting")]
+    fn apply_response_hook_to_snapshot(
+        &self,
+        mut parts: http::response::Parts,
+        captured_body: Bytes,
+    ) -> HookedResponse {
+        if let Some(ref engine) = self.script_engine {
+            let (req_method, req_url) = self
+                .captured_request
+                .as_ref()
+                .map(CapturedRequest::request_line)
+                .unwrap_or_default();
+
+            match engine.on_response(
+                &req_method,
+                &req_url,
+                parts.status.as_u16(),
+                &parts.headers,
+                &captured_body,
+            ) {
+                Ok(crate::scripting::ScriptResponseAction::Modified {
+                    status,
+                    headers,
+                    body,
+                }) => {
+                    if let Ok(s) = http::StatusCode::from_u16(status) {
+                        parts.status = s;
+                    }
+                    parts.headers = headers;
+                    let body = if body == captured_body {
+                        HookedResponseBody::Original(captured_body)
+                    } else {
+                        HookedResponseBody::Replaced(body)
+                    };
+                    return HookedResponse { parts, body };
+                }
+                Ok(crate::scripting::ScriptResponseAction::PassThrough) => {}
+                Err(e) => {
+                    tracing::warn!("Lua on_response error (passing through): {e}");
+                }
+            }
+        }
+
+        HookedResponse {
+            parts,
+            body: HookedResponseBody::Original(captured_body),
+        }
+    }
+
+    #[cfg(not(feature = "scripting"))]
+    fn apply_response_hook_to_snapshot(
+        &self,
+        parts: http::response::Parts,
+        captured_body: Bytes,
+    ) -> HookedResponse {
+        HookedResponse {
+            parts,
+            body: HookedResponseBody::Original(captured_body),
+        }
+    }
+
+    pub(crate) fn emit_response_snapshot(&mut self, parts: &http::response::Parts, body: Bytes) {
+        let proxied_response = ProxiedResponse::new(
+            parts.status,
+            parts.version,
+            parts.headers.clone(),
+            body,
+            now_millis(),
+        );
+
+        if let Some(request) = self.take_captured_request() {
+            // Use the ID assigned at the start of handle_request (intercept flow)
+            // so that RequestIntercepted and RequestComplete share the same ID.
+            // Fall back to next_id() for the normal (non-intercept) path.
+            let id = self.pending_id.take().unwrap_or_else(next_id);
+            let event = ProxyEvent::RequestComplete {
+                id,
+                request: Box::new(request),
+                response: Box::new(proxied_response),
+            };
+            self.send_event(event);
+        }
+    }
+
+    fn forward_request_from_body(
+        &mut self,
+        parts: http::request::Parts,
+        request_body: RequestBody,
+    ) -> Request<ProxyBody> {
+        match request_body {
+            RequestBody::Buffered(body_bytes) => {
+                self.captured_request = Some(CapturedRequest::buffered(ProxiedRequest::new(
+                    parts.method.clone(),
+                    parts.uri.clone(),
+                    parts.version,
+                    parts.headers.clone(),
+                    body_bytes.clone(),
+                    now_millis(),
+                )));
+                Request::from_parts(parts, body::full(body_bytes))
+            }
+            RequestBody::Streaming { captured, body } => {
+                self.captured_request = Some(CapturedRequest::buffered(ProxiedRequest::new(
+                    parts.method.clone(),
+                    parts.uri.clone(),
+                    parts.version,
+                    parts.headers.clone(),
+                    captured,
+                    now_millis(),
+                )));
+                Request::from_parts(parts, body)
             }
         }
     }
@@ -295,24 +703,40 @@ impl HttpHandler for CapturingHandler {
         self.pending_id = Some(id);
 
         let (mut parts, incoming) = req.into_parts();
-        let mut body_bytes = Limited::new(incoming, MAX_BODY_SIZE)
-            .collect()
-            .await
-            .map(http_body_util::Collected::to_bytes)
-            .unwrap_or_else(|e| {
-                tracing::warn!("Failed to collect request body: {e}");
-                Bytes::new()
-            });
+        if !self.should_buffer_request() {
+            let capture = BodyCapture::new(self.body_capture_limit);
+            let done = Arc::new(Notify::new());
+            self.captured_request = Some(CapturedRequest::streaming(
+                &parts,
+                capture.clone(),
+                Arc::clone(&done),
+                now_millis(),
+            ));
+            let req = Request::from_parts(
+                parts,
+                body::capture(incoming, capture, move || done.notify_one()),
+            );
+            return RequestOrResponse::Request(req);
+        }
+
+        let mut request_body =
+            match collect_body(incoming, self.body_capture_limit, "request").await {
+                BodyCollection::Complete(bytes) => RequestBody::Buffered(bytes),
+                BodyCollection::Exceeded { captured, body } => {
+                    RequestBody::Streaming { captured, body }
+                }
+            };
 
         // Run Lua on_request hook (if scripting is enabled and a script is loaded).
-        // This runs synchronously — the body has already been collected above.
+        // This runs synchronously with the complete body or the capped snapshot.
         #[cfg(feature = "scripting")]
         if let Some(ref engine) = self.script_engine {
+            let hook_body = request_body.hook_bytes().clone();
             match engine.on_request(
                 parts.method.as_str(),
                 &parts.uri.to_string(),
                 &parts.headers,
-                &body_bytes,
+                &hook_body,
             ) {
                 Ok(crate::scripting::ScriptRequestAction::Forward {
                     method,
@@ -327,7 +751,7 @@ impl HttpHandler for CapturingHandler {
                         parts.uri = u;
                     }
                     parts.headers = headers;
-                    body_bytes = body;
+                    request_body.apply_modified_body(&hook_body, body);
                 }
                 Ok(crate::scripting::ScriptRequestAction::ShortCircuit {
                     status,
@@ -340,10 +764,10 @@ impl HttpHandler for CapturingHandler {
                         parts.uri.clone(),
                         parts.version,
                         parts.headers.clone(),
-                        body_bytes.clone(),
+                        request_body.hook_bytes().clone(),
                         now_millis(),
                     );
-                    self.captured_request = Some(proxied_request);
+                    self.captured_request = Some(CapturedRequest::buffered(proxied_request));
 
                     let status_code = http::StatusCode::from_u16(status)
                         .unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR);
@@ -371,7 +795,7 @@ impl HttpHandler for CapturingHandler {
                     parts.uri.clone(),
                     parts.version,
                     parts.headers.clone(),
-                    body_bytes.clone(),
+                    request_body.hook_bytes().clone(),
                     now_millis(),
                 );
                 // Register before sending the event so the UI can always resolve.
@@ -386,7 +810,7 @@ impl HttpHandler for CapturingHandler {
                     cfg.resolve(id, InterceptDecision::Forward);
                     tracing::warn!("Event channel full, skipping intercept for id={id}");
                 } else {
-                    self.captured_request = Some(snapshot);
+                    self.captured_request = Some(CapturedRequest::buffered(snapshot));
 
                     match tokio::time::timeout(std::time::Duration::from_secs(300), rx).await {
                         Ok(Ok(InterceptDecision::Forward)) => {
@@ -405,16 +829,8 @@ impl HttpHandler for CapturingHandler {
                                 parts.uri = u;
                             }
                             parts.headers = headers;
-                            body_bytes = body;
-                            // Update the captured snapshot to reflect the edits.
-                            self.captured_request = Some(ProxiedRequest::new(
-                                parts.method.clone(),
-                                parts.uri.clone(),
-                                parts.version,
-                                parts.headers.clone(),
-                                body_bytes.clone(),
-                                now_millis(),
-                            ));
+                            let hook_body = request_body.hook_bytes().clone();
+                            request_body.apply_modified_body(&hook_body, body);
                         }
                         Ok(Ok(InterceptDecision::Block { status, body })) => {
                             // Short-circuit: captured_request is already set above.
@@ -438,23 +854,13 @@ impl HttpHandler for CapturingHandler {
                         }
                     }
 
-                    let req = Request::from_parts(parts, body::full(body_bytes));
+                    let req = self.forward_request_from_body(parts, request_body);
                     return RequestOrResponse::Request(req);
                 }
             }
         }
 
-        let proxied_request = ProxiedRequest::new(
-            parts.method.clone(),
-            parts.uri.clone(),
-            parts.version,
-            parts.headers.clone(),
-            body_bytes.clone(),
-            now_millis(),
-        );
-        self.captured_request = Some(proxied_request);
-
-        let req = Request::from_parts(parts, body::full(body_bytes));
+        let req = self.forward_request_from_body(parts, request_body);
         RequestOrResponse::Request(req)
     }
 
@@ -463,9 +869,7 @@ impl HttpHandler for CapturingHandler {
         _ctx: &HttpContext,
         res: Response<hyper::body::Incoming>,
     ) -> Response<ProxyBody> {
-        let (parts, incoming) = res.into_parts();
-        let body_bytes = collect_body(incoming).await;
-        collect_and_emit(self, parts, body_bytes)
+        self.handle_upstream_response(res).await
     }
 }
 
@@ -496,7 +900,7 @@ mod tests {
     fn debug_does_not_expose_large_captured_request() {
         let (event_tx, _event_rx) = mpsc::channel(1);
         let mut handler = CapturingHandler::new(event_tx);
-        handler.captured_request = Some(proxied_request());
+        handler.captured_request = Some(CapturedRequest::buffered(proxied_request()));
 
         let debug = format!("{handler:?}");
 
@@ -510,11 +914,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_and_emit_uses_pending_id_and_rebuilds_response_body() {
+    async fn finish_buffered_response_uses_pending_id_and_rebuilds_response_body() {
         let (event_tx, mut event_rx) = mpsc::channel(1);
         let mut handler = CapturingHandler::new(event_tx);
         handler.pending_id = Some(77);
-        handler.captured_request = Some(proxied_request());
+        handler.captured_request = Some(CapturedRequest::buffered(proxied_request()));
 
         let (mut parts, _) = Response::builder()
             .status(StatusCode::ACCEPTED)
@@ -524,7 +928,7 @@ mod tests {
             .into_parts();
         parts.version = Version::HTTP_11;
 
-        let response = collect_and_emit(&mut handler, parts, Bytes::from_static(b"accepted"));
+        let response = handler.finish_buffered_response(parts, Bytes::from_static(b"accepted"));
 
         assert_eq!(body_bytes(response).await.as_ref(), b"accepted");
         match event_rx.recv().await.unwrap() {
@@ -544,7 +948,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_and_emit_without_captured_request_sends_no_event() {
+    async fn finish_buffered_response_without_captured_request_sends_no_event() {
         let (event_tx, mut event_rx) = mpsc::channel(1);
         let mut handler = CapturingHandler::new(event_tx);
         let (parts, _) = Response::builder()
@@ -553,10 +957,180 @@ mod tests {
             .unwrap()
             .into_parts();
 
-        let response = collect_and_emit(&mut handler, parts, Bytes::new());
+        let response = handler.finish_buffered_response(parts, Bytes::new());
 
         assert!(body_bytes(response).await.is_empty());
         assert!(event_rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn stream_response_forwards_full_body_and_emits_capped_snapshots() {
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let mut handler = CapturingHandler::new(event_tx);
+        handler.body_capture_limit = 4;
+        handler.pending_id = Some(88);
+
+        let (req_parts, _) = Request::builder()
+            .method(Method::POST)
+            .uri("http://example.test/upload")
+            .body(())
+            .unwrap()
+            .into_parts();
+        let request_capture = BodyCapture::new(4);
+        request_capture.append(&Bytes::from_static(b"abcdef"));
+        let request_done = Arc::new(Notify::new());
+        request_done.notify_one();
+        handler.captured_request = Some(CapturedRequest::streaming(
+            &req_parts,
+            request_capture,
+            request_done,
+            10,
+        ));
+
+        let (parts, _) = Response::builder()
+            .status(StatusCode::OK)
+            .body(())
+            .unwrap()
+            .into_parts();
+        let response = handler.stream_response(parts, body::full(Bytes::from_static(b"uvwxyz")));
+
+        assert_eq!(body_bytes(response).await.as_ref(), b"uvwxyz");
+        match event_rx.recv().await.unwrap() {
+            ProxyEvent::RequestComplete {
+                id,
+                request,
+                response,
+            } => {
+                assert_eq!(id, 88);
+                assert_eq!(request.body().as_ref(), b"abcd");
+                assert_eq!(response.body().as_ref(), b"uvwx");
+            }
+            other => panic!("expected RequestComplete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_response_emits_partial_capture_when_body_is_dropped() {
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let mut handler = CapturingHandler::new(event_tx);
+        handler.pending_id = Some(90);
+        handler.captured_request = Some(CapturedRequest::buffered(proxied_request()));
+
+        let (parts, _) = Response::builder()
+            .status(StatusCode::OK)
+            .body(())
+            .unwrap()
+            .into_parts();
+        let response =
+            handler.stream_response(parts, body::full(Bytes::from_static(b"not consumed")));
+
+        drop(response);
+
+        match event_rx.try_recv().unwrap() {
+            ProxyEvent::RequestComplete {
+                id,
+                request,
+                response,
+            } => {
+                assert_eq!(id, 90);
+                assert_eq!(request.uri().path(), "/path");
+                assert_eq!(response.status(), StatusCode::OK);
+                assert!(response.body().is_empty());
+            }
+            other => panic!("expected RequestComplete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_response_emits_for_already_empty_body() {
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let mut handler = CapturingHandler::new(event_tx);
+        handler.pending_id = Some(89);
+        handler.captured_request = Some(CapturedRequest::buffered(proxied_request()));
+
+        let (parts, _) = Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(())
+            .unwrap()
+            .into_parts();
+
+        let response = handler.stream_response(parts, body::empty());
+
+        assert!(body_bytes(response).await.is_empty());
+        match event_rx.recv().await.unwrap() {
+            ProxyEvent::RequestComplete {
+                id,
+                request,
+                response,
+            } => {
+                assert_eq!(id, 89);
+                assert_eq!(request.uri().path(), "/path");
+                assert_eq!(response.status(), StatusCode::NO_CONTENT);
+                assert!(response.body().is_empty());
+            }
+            other => panic!("expected RequestComplete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_response_waits_for_streaming_request_capture_before_empty_response_event() {
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let mut handler = CapturingHandler::new(event_tx);
+        handler.pending_id = Some(91);
+
+        let (req_parts, _) = Request::builder()
+            .method(Method::POST)
+            .uri("http://example.test/upload")
+            .body(())
+            .unwrap()
+            .into_parts();
+        let request_capture = BodyCapture::new(10);
+        request_capture.append(&Bytes::from_static(b"abc"));
+        let request_done = Arc::new(Notify::new());
+        handler.captured_request = Some(CapturedRequest::streaming(
+            &req_parts,
+            request_capture.clone(),
+            Arc::clone(&request_done),
+            10,
+        ));
+
+        let (parts, _) = Response::builder()
+            .status(StatusCode::NO_CONTENT)
+            .body(())
+            .unwrap()
+            .into_parts();
+        let response = handler.stream_response(parts, body::empty());
+
+        assert!(body_bytes(response).await.is_empty());
+        tokio::task::yield_now().await;
+        assert!(event_rx.try_recv().is_err());
+
+        request_capture.append(&Bytes::from_static(b"def"));
+        request_done.notify_one();
+
+        match event_rx.recv().await.unwrap() {
+            ProxyEvent::RequestComplete {
+                id,
+                request,
+                response,
+            } => {
+                assert_eq!(id, 91);
+                assert_eq!(request.body().as_ref(), b"abcdef");
+                assert_eq!(response.status(), StatusCode::NO_CONTENT);
+            }
+            other => panic!("expected RequestComplete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn collect_body_returns_streaming_body_when_limit_is_exceeded() {
+        match collect_body(body::full(Bytes::from_static(b"abcdef")), 4, "response").await {
+            BodyCollection::Complete(_) => panic!("expected limit fallback"),
+            BodyCollection::Exceeded { captured, body } => {
+                assert_eq!(captured.as_ref(), b"abcd");
+                assert_eq!(body.collect().await.unwrap().to_bytes().as_ref(), b"abcdef");
+            }
+        }
     }
 
     #[tokio::test]
@@ -575,7 +1149,10 @@ mod tests {
         let body = request.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(body.as_ref(), b"request body");
         assert!(handler.pending_id.is_some());
-        assert_eq!(handler.captured_request.unwrap().uri().path(), "/path");
+        assert_eq!(
+            handler.take_captured_request().unwrap().uri().path(),
+            "/path"
+        );
     }
 
     #[test]
@@ -746,7 +1323,7 @@ mod tests {
 
     #[cfg(feature = "scripting")]
     #[tokio::test]
-    async fn collect_and_emit_runs_script_response_hook() {
+    async fn finish_buffered_response_runs_script_response_hook() {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
@@ -767,7 +1344,7 @@ mod tests {
         let engine = Arc::new(crate::scripting::ScriptEngine::new(file.path()).unwrap());
         let (event_tx, mut event_rx) = mpsc::channel(1);
         let mut handler = CapturingHandler::new(event_tx).with_script_engine(engine);
-        handler.captured_request = Some(proxied_request());
+        handler.captured_request = Some(CapturedRequest::buffered(proxied_request()));
 
         let (parts, _) = Response::builder()
             .status(StatusCode::OK)
@@ -775,7 +1352,7 @@ mod tests {
             .unwrap()
             .into_parts();
 
-        let response = collect_and_emit(&mut handler, parts, Bytes::from_static(b"original"));
+        let response = handler.finish_buffered_response(parts, Bytes::from_static(b"original"));
 
         assert_eq!(response.status(), StatusCode::CREATED);
         assert_eq!(response.headers()["x-script"], "yes");
@@ -792,7 +1369,7 @@ mod tests {
 
     #[cfg(feature = "scripting")]
     #[tokio::test]
-    async fn collect_and_emit_passes_through_on_script_response_error() {
+    async fn finish_buffered_response_passes_through_on_script_response_error() {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
@@ -817,7 +1394,7 @@ mod tests {
             .unwrap()
             .into_parts();
 
-        let response = collect_and_emit(&mut handler, parts, Bytes::from_static(b"original"));
+        let response = handler.finish_buffered_response(parts, Bytes::from_static(b"original"));
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(body_bytes(response).await.as_ref(), b"original");
@@ -825,7 +1402,7 @@ mod tests {
 
     #[cfg(feature = "scripting")]
     #[tokio::test]
-    async fn collect_and_emit_passes_through_when_script_returns_nil_response() {
+    async fn finish_buffered_response_passes_through_when_script_returns_nil_response() {
         use std::io::Write;
         use tempfile::NamedTempFile;
 
@@ -843,7 +1420,7 @@ mod tests {
         let engine = Arc::new(crate::scripting::ScriptEngine::new(file.path()).unwrap());
         let (event_tx, mut event_rx) = mpsc::channel(1);
         let mut handler = CapturingHandler::new(event_tx).with_script_engine(engine);
-        handler.captured_request = Some(proxied_request());
+        handler.captured_request = Some(CapturedRequest::buffered(proxied_request()));
 
         let (parts, _) = Response::builder()
             .status(StatusCode::OK)
@@ -852,7 +1429,7 @@ mod tests {
             .unwrap()
             .into_parts();
 
-        let response = collect_and_emit(&mut handler, parts, Bytes::from_static(b"original"));
+        let response = handler.finish_buffered_response(parts, Bytes::from_static(b"original"));
 
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.headers()["x-original-response"], "yes");

--- a/proxyapi/src/handler.rs
+++ b/proxyapi/src/handler.rs
@@ -12,11 +12,11 @@ use crate::event::{next_id, ProxyEvent};
 use crate::intercept::{InterceptConfig, InterceptDecision};
 use crate::{HttpContext, HttpHandler, RequestOrResponse};
 
-/// Default maximum body size the proxy buffers for capture/editing (100 MB).
+/// Default body capture limit.
 ///
-/// Larger bodies are streamed through unchanged when possible, with stored
-/// captures capped at this size.
-pub const DEFAULT_BODY_CAPTURE_LIMIT: usize = 100 * 1024 * 1024;
+/// `None` keeps the default mitmproxy-style behavior: buffer complete HTTP
+/// bodies for capture/editing unless the user configures an explicit limit.
+pub const DEFAULT_BODY_CAPTURE_LIMIT: Option<usize> = None;
 
 enum BodyCollection {
     Complete(Bytes),
@@ -205,7 +205,7 @@ impl HookedResponseBody {
 ///
 /// When the body exceeds the limit, returns a reconstructed streaming body that
 /// first replays already-read bytes, then continues the original body.
-async fn collect_body<B>(mut body: B, limit: usize, kind: &'static str) -> BodyCollection
+async fn collect_body<B>(mut body: B, limit: Option<usize>, kind: &'static str) -> BodyCollection
 where
     B: HttpBody<Data = Bytes, Error = hyper::Error> + Send + Sync + Unpin + 'static,
 {
@@ -221,6 +221,11 @@ where
         };
 
         let Ok(data) = frame.into_data() else {
+            continue;
+        };
+
+        let Some(limit) = limit else {
+            buffer.extend_from_slice(&data);
             continue;
         };
 
@@ -258,7 +263,7 @@ pub struct CapturingHandler {
     /// share the same ID and the UI can correlate them.
     pending_id: Option<u64>,
     intercept: Option<Arc<InterceptConfig>>,
-    body_capture_limit: usize,
+    body_capture_limit: Option<usize>,
     #[cfg(feature = "scripting")]
     script_engine: Option<Arc<crate::scripting::ScriptEngine>>,
 }
@@ -291,10 +296,10 @@ impl CapturingHandler {
 
     /// Set the maximum body bytes buffered for capture and byte-editing paths.
     ///
-    /// Bodies above this limit are streamed through unchanged and captured only
-    /// up to the configured limit.
+    /// `None` means unlimited capture. `Some(limit)` streams bodies above the
+    /// limit through unchanged and captures only up to the configured limit.
     #[must_use]
-    pub fn with_body_capture_limit(mut self, limit: usize) -> Self {
+    pub fn with_body_capture_limit(mut self, limit: Option<usize>) -> Self {
         self.body_capture_limit = limit;
         self
     }
@@ -967,7 +972,7 @@ mod tests {
     async fn stream_response_forwards_full_body_and_emits_capped_snapshots() {
         let (event_tx, mut event_rx) = mpsc::channel(1);
         let mut handler = CapturingHandler::new(event_tx);
-        handler.body_capture_limit = 4;
+        handler.body_capture_limit = Some(4);
         handler.pending_id = Some(88);
 
         let (req_parts, _) = Request::builder()
@@ -976,7 +981,7 @@ mod tests {
             .body(())
             .unwrap()
             .into_parts();
-        let request_capture = BodyCapture::new(4);
+        let request_capture = BodyCapture::new(Some(4));
         request_capture.append(&Bytes::from_static(b"abcdef"));
         let request_done = Arc::new(Notify::new());
         request_done.notify_one();
@@ -1084,7 +1089,7 @@ mod tests {
             .body(())
             .unwrap()
             .into_parts();
-        let request_capture = BodyCapture::new(10);
+        let request_capture = BodyCapture::new(Some(10));
         request_capture.append(&Bytes::from_static(b"abc"));
         let request_done = Arc::new(Notify::new());
         handler.captured_request = Some(CapturedRequest::streaming(
@@ -1124,12 +1129,26 @@ mod tests {
 
     #[tokio::test]
     async fn collect_body_returns_streaming_body_when_limit_is_exceeded() {
-        match collect_body(body::full(Bytes::from_static(b"abcdef")), 4, "response").await {
+        match collect_body(
+            body::full(Bytes::from_static(b"abcdef")),
+            Some(4),
+            "response",
+        )
+        .await
+        {
             BodyCollection::Complete(_) => panic!("expected limit fallback"),
             BodyCollection::Exceeded { captured, body } => {
                 assert_eq!(captured.as_ref(), b"abcd");
                 assert_eq!(body.collect().await.unwrap().to_bytes().as_ref(), b"abcdef");
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn collect_body_buffers_full_body_when_unlimited() {
+        match collect_body(body::full(Bytes::from_static(b"abcdef")), None, "response").await {
+            BodyCollection::Complete(body) => assert_eq!(body.as_ref(), b"abcdef"),
+            BodyCollection::Exceeded { .. } => panic!("expected complete body"),
         }
     }
 

--- a/proxyapi/src/lib.rs
+++ b/proxyapi/src/lib.rs
@@ -22,7 +22,7 @@ use std::net::SocketAddr;
 
 pub use error::Error;
 pub use event::ProxyEvent;
-pub use handler::CapturingHandler;
+pub use handler::{CapturingHandler, DEFAULT_BODY_CAPTURE_LIMIT};
 pub use intercept::{InterceptConfig, InterceptDecision};
 pub use proxy::{Proxy, ProxyConfig, ProxyMode};
 

--- a/proxyapi/src/proxy/forward.rs
+++ b/proxyapi/src/proxy/forward.rs
@@ -31,7 +31,7 @@ const TLS_RECORD_HANDSHAKE: u8 = 0x16;
 /// TLS major version byte (SSLv3 / TLS 1.x).
 const TLS_VERSION_MAJOR: u8 = 0x03;
 /// Maximum payload size captured per WebSocket frame.
-const MAX_WS_FRAME_PAYLOAD: usize = crate::handler::DEFAULT_BODY_CAPTURE_LIMIT;
+const MAX_WS_FRAME_PAYLOAD: Option<usize> = crate::handler::DEFAULT_BODY_CAPTURE_LIMIT;
 
 /// Returns true when the request carries WebSocket upgrade tokens.
 fn is_websocket_upgrade<B>(req: &Request<B>) -> bool {
@@ -542,8 +542,9 @@ fn emit_ws_frame(
         Message::Close(_) => (WsOpcode::Close, b""),
         Message::Frame(_) => (WsOpcode::Continuation, b""),
     };
-    let truncated = raw.len() > MAX_WS_FRAME_PAYLOAD;
-    let payload = Bytes::copy_from_slice(&raw[..raw.len().min(MAX_WS_FRAME_PAYLOAD)]);
+    let limit = MAX_WS_FRAME_PAYLOAD.unwrap_or(raw.len());
+    let truncated = raw.len() > limit;
+    let payload = Bytes::copy_from_slice(&raw[..raw.len().min(limit)]);
     let _ = tx.try_send(ProxyEvent::WebSocketFrame {
         conn_id,
         frame: Box::new(WsFrame::new(direction, opcode, time, payload, truncated)),

--- a/proxyapi/src/proxy/forward.rs
+++ b/proxyapi/src/proxy/forward.rs
@@ -18,7 +18,7 @@ use proxyapi_models::{ProxiedRequest, ProxiedResponse, WsDirection, WsFrame, WsO
 use crate::body::{self, ProxyBody};
 use crate::ca::{cert_server, CertificateAuthority, Ssl};
 use crate::event::ProxyEvent;
-use crate::handler::{collect_and_emit, collect_body, now_millis, CapturingHandler};
+use crate::handler::{now_millis, CapturingHandler};
 use crate::rewind::Rewind;
 use crate::{HttpContext, HttpHandler, RequestOrResponse};
 
@@ -30,8 +30,8 @@ const HTTP_GET_PREFIX: &[u8; 4] = b"GET ";
 const TLS_RECORD_HANDSHAKE: u8 = 0x16;
 /// TLS major version byte (SSLv3 / TLS 1.x).
 const TLS_VERSION_MAJOR: u8 = 0x03;
-/// Maximum payload size captured per WebSocket frame (100 MB, matches MAX_BODY_SIZE).
-const MAX_WS_FRAME_PAYLOAD: usize = 100 * 1024 * 1024;
+/// Maximum payload size captured per WebSocket frame.
+const MAX_WS_FRAME_PAYLOAD: usize = crate::handler::DEFAULT_BODY_CAPTURE_LIMIT;
 
 /// Returns true when the request carries WebSocket upgrade tokens.
 fn is_websocket_upgrade<B>(req: &Request<B>) -> bool {
@@ -136,9 +136,7 @@ pub async fn handle_connection(
 
                         Ok(Response::from_parts(parts, body::empty()))
                     } else {
-                        let (parts, body) = res.into_parts();
-                        let body_bytes = collect_body(body).await;
-                        Ok(collect_and_emit(&mut handler, parts, body_bytes))
+                        Ok(handler.handle_upstream_response(res).await)
                     }
                 }
                 Err(e) => {
@@ -413,9 +411,7 @@ where
 
                         Ok(Response::from_parts(parts, body::empty()))
                     } else {
-                        let (parts, body) = res.into_parts();
-                        let body_bytes = collect_body(body).await;
-                        Ok(collect_and_emit(&mut handler, parts, body_bytes))
+                        Ok(handler.handle_upstream_response(res).await)
                     }
                 }
                 Err(e) => {
@@ -568,9 +564,7 @@ pub(crate) async fn handle_replay(
     };
     match client.request(normalize_request(fwd_req)).await {
         Ok(res) => {
-            let (parts, body) = res.into_parts();
-            let body_bytes = collect_body(body).await;
-            collect_and_emit(&mut handler, parts, body_bytes);
+            handler.record_upstream_response(res).await;
         }
         Err(e) => tracing::warn!("Replay request failed: {e}"),
     }

--- a/proxyapi/src/proxy/mod.rs
+++ b/proxyapi/src/proxy/mod.rs
@@ -44,6 +44,8 @@ pub struct ProxyConfig {
     pub ca_dir: PathBuf,
     /// Optional intercept controller for interactive request/response editing.
     pub intercept: Option<Arc<InterceptConfig>>,
+    /// Maximum body bytes buffered for capture/editing before streaming passthrough.
+    pub body_capture_limit: usize,
     /// Optional path to a Lua script for request/response hooks.
     #[cfg(feature = "scripting")]
     pub script_path: Option<PathBuf>,
@@ -119,7 +121,8 @@ impl Proxy {
                             continue;
                         }
                     };
-                    let mut handler = CapturingHandler::new(self.config.event_tx.clone());
+                    let mut handler = CapturingHandler::new(self.config.event_tx.clone())
+                        .with_body_capture_limit(self.config.body_capture_limit);
                     if let Some(ref ic) = self.config.intercept {
                         handler = handler.with_intercept(Arc::clone(ic));
                     }
@@ -146,7 +149,8 @@ impl Proxy {
                     }
                 }
                 Some(req) = recv_replay(&mut replay_rx) => {
-                    let mut handler = CapturingHandler::new(self.config.event_tx.clone());
+                    let mut handler = CapturingHandler::new(self.config.event_tx.clone())
+                        .with_body_capture_limit(self.config.body_capture_limit);
                     if let Some(ref ic) = self.config.intercept {
                         handler = handler.with_intercept(Arc::clone(ic));
                     }
@@ -181,6 +185,7 @@ async fn recv_replay(rx: &mut Option<mpsc::Receiver<ProxiedRequest>>) -> Option<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::handler::DEFAULT_BODY_CAPTURE_LIMIT;
     use bytes::Bytes;
     use http::{HeaderMap, Method, Version};
     use std::io;
@@ -207,6 +212,7 @@ mod tests {
             event_tx,
             ca_dir: PathBuf::from("."),
             intercept: None,
+            body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
             #[cfg(feature = "scripting")]
             script_path: None,
             replay_rx: None,

--- a/proxyapi/src/proxy/mod.rs
+++ b/proxyapi/src/proxy/mod.rs
@@ -45,7 +45,9 @@ pub struct ProxyConfig {
     /// Optional intercept controller for interactive request/response editing.
     pub intercept: Option<Arc<InterceptConfig>>,
     /// Maximum body bytes buffered for capture/editing before streaming passthrough.
-    pub body_capture_limit: usize,
+    ///
+    /// `None` means unlimited capture.
+    pub body_capture_limit: Option<usize>,
     /// Optional path to a Lua script for request/response hooks.
     #[cfg(feature = "scripting")]
     pub script_path: Option<PathBuf>,

--- a/proxyapi/src/proxy/reverse.rs
+++ b/proxyapi/src/proxy/reverse.rs
@@ -8,7 +8,7 @@ use hyper_util::rt::TokioIo;
 use tokio::net::TcpStream;
 
 use crate::body::{self, ProxyBody};
-use crate::handler::{collect_and_emit, collect_body, CapturingHandler};
+use crate::handler::CapturingHandler;
 use crate::{HttpContext, HttpHandler, RequestOrResponse};
 
 use super::{is_benign_shutdown_error, Client};
@@ -48,11 +48,7 @@ pub async fn handle_connection(
             };
 
             match client.request(req).await {
-                Ok(res) => {
-                    let (parts, body) = res.into_parts();
-                    let body_bytes = collect_body(body).await;
-                    Ok(collect_and_emit(&mut handler, parts, body_bytes))
-                }
+                Ok(res) => Ok(handler.handle_upstream_response(res).await),
                 Err(e) => {
                     tracing::error!("Reverse proxy error: {e}");
                     Ok(Response::builder()

--- a/proxyapi/tests/forward_proxy.rs
+++ b/proxyapi/tests/forward_proxy.rs
@@ -5,7 +5,7 @@ use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
-use proxyapi::{Proxy, ProxyConfig, ProxyEvent, ProxyMode};
+use proxyapi::{Proxy, ProxyConfig, ProxyEvent, ProxyMode, DEFAULT_BODY_CAPTURE_LIMIT};
 use proxyapi_models::ProxiedRequest;
 use std::net::SocketAddr;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -29,6 +29,7 @@ async fn test_forward_proxy_starts_and_shuts_down() {
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
         replay_rx: None,
@@ -507,6 +508,7 @@ async fn start_forward_proxy() -> (
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
         replay_rx: None,
@@ -545,6 +547,7 @@ async fn start_forward_proxy_with_replay() -> (
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
         replay_rx: Some(replay_rx),

--- a/proxyapi/tests/forward_proxy.rs
+++ b/proxyapi/tests/forward_proxy.rs
@@ -15,6 +15,8 @@ use tokio_tungstenite::tungstenite::protocol::Role;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
 
+const EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[tokio::test]
 async fn test_forward_proxy_starts_and_shuts_down() {
     let _ = rustls::crypto::ring::default_provider().install_default();
@@ -783,7 +785,7 @@ fn assert_response_header(response: &str, name: &str, value: &str) {
 }
 
 async fn recv_request_complete(event_rx: &mut mpsc::Receiver<ProxyEvent>) -> ProxyEvent {
-    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+    tokio::time::timeout(EVENT_TIMEOUT, async {
         loop {
             let event = event_rx.recv().await.unwrap();
             if matches!(event, ProxyEvent::RequestComplete { .. }) {

--- a/proxyapi/tests/reverse_proxy.rs
+++ b/proxyapi/tests/reverse_proxy.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
+const EVENT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[tokio::test]
 async fn test_reverse_proxy_starts_and_shuts_down() {
     let _ = rustls::crypto::ring::default_provider().install_default();
@@ -99,7 +101,7 @@ async fn reverse_proxy_forwards_http_and_emits_request_complete() {
     assert_eq!(response.headers()["x-upstream-path"], "/hello");
     assert_eq!(response.text().await.unwrap(), "upstream response");
 
-    let event = tokio::time::timeout(std::time::Duration::from_secs(2), event_rx.recv())
+    let event = tokio::time::timeout(EVENT_TIMEOUT, event_rx.recv())
         .await
         .unwrap()
         .unwrap();
@@ -217,7 +219,7 @@ async fn reverse_proxy_intercepts_oversized_request_before_streaming_original() 
             .unwrap()
     });
 
-    let intercepted = tokio::time::timeout(std::time::Duration::from_secs(2), event_rx.recv())
+    let intercepted = tokio::time::timeout(EVENT_TIMEOUT, event_rx.recv())
         .await
         .unwrap()
         .unwrap();

--- a/proxyapi/tests/reverse_proxy.rs
+++ b/proxyapi/tests/reverse_proxy.rs
@@ -190,7 +190,7 @@ async fn reverse_proxy_intercepts_oversized_request_before_streaming_original() 
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: Some(Arc::clone(&intercept)),
-        body_capture_limit: 4,
+        body_capture_limit: Some(4),
         #[cfg(feature = "scripting")]
         script_path: None,
         replay_rx: None,
@@ -292,7 +292,7 @@ async fn reverse_proxy_runs_scripts_for_oversized_request_and_response() {
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: None,
-        body_capture_limit: 4,
+        body_capture_limit: Some(4),
         script_path: Some(script.path().to_path_buf()),
         replay_rx: None,
     };

--- a/proxyapi/tests/reverse_proxy.rs
+++ b/proxyapi/tests/reverse_proxy.rs
@@ -1,11 +1,15 @@
 use bytes::Bytes;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::TokioIo;
-use proxyapi::{Proxy, ProxyConfig, ProxyEvent, ProxyMode};
+use proxyapi::{
+    InterceptConfig, InterceptDecision, Proxy, ProxyConfig, ProxyEvent, ProxyMode,
+    DEFAULT_BODY_CAPTURE_LIMIT,
+};
 use std::net::SocketAddr;
+use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 
@@ -25,6 +29,7 @@ async fn test_reverse_proxy_starts_and_shuts_down() {
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
         replay_rx: None,
@@ -65,6 +70,7 @@ async fn reverse_proxy_forwards_http_and_emits_request_complete() {
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
         replay_rx: None,
@@ -134,6 +140,7 @@ async fn reverse_proxy_returns_502_when_target_is_unreachable() {
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
         intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
         replay_rx: None,
@@ -162,6 +169,160 @@ async fn reverse_proxy_returns_502_when_target_is_unreachable() {
     assert!(event_rx.try_recv().is_err());
 
     let _ = shutdown_tx.send(());
+    assert!(handle.await.unwrap().is_ok());
+}
+
+#[tokio::test]
+async fn reverse_proxy_intercepts_oversized_request_before_streaming_original() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown) = start_echo_request_body_server().await;
+    let proxy_addr = reserve_loopback_addr().await;
+    let ca_dir = tempfile::tempdir().unwrap();
+    let intercept = InterceptConfig::new();
+    intercept.set_enabled(true);
+
+    let (event_tx, mut event_rx) = mpsc::channel::<ProxyEvent>(100);
+    let config = ProxyConfig {
+        addr: proxy_addr,
+        mode: ProxyMode::Reverse {
+            target: format!("http://{upstream_addr}").parse().unwrap(),
+        },
+        event_tx,
+        ca_dir: ca_dir.path().to_path_buf(),
+        intercept: Some(Arc::clone(&intercept)),
+        body_capture_limit: 4,
+        #[cfg(feature = "scripting")]
+        script_path: None,
+        replay_rx: None,
+    };
+
+    let proxy = Proxy::new(config);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let handle = tokio::spawn(async move {
+        proxy
+            .start(async {
+                shutdown_rx.await.ok();
+            })
+            .await
+    });
+
+    wait_for_tcp(proxy_addr).await;
+
+    let response_task = tokio::spawn(async move {
+        reqwest::Client::new()
+            .post(format!("http://{proxy_addr}/upload"))
+            .body("abcdef")
+            .send()
+            .await
+            .unwrap()
+    });
+
+    let intercepted = tokio::time::timeout(std::time::Duration::from_secs(2), event_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let (id, method, uri, mut headers, body) = match intercepted {
+        ProxyEvent::RequestIntercepted { id, request } => {
+            assert_eq!(request.uri().path(), "/upload");
+            assert_eq!(request.body().as_ref(), b"abcd");
+            (
+                id,
+                request.method().to_string(),
+                request.uri().to_string(),
+                request.headers().clone(),
+                request.body().clone(),
+            )
+        }
+        other => panic!("expected RequestIntercepted event, got {other:?}"),
+    };
+    headers.insert("x-intercept", "yes".parse().unwrap());
+    assert!(intercept.resolve(
+        id,
+        InterceptDecision::Modified {
+            method,
+            uri,
+            headers,
+            body,
+        },
+    ));
+
+    let response = response_task.await.unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    assert_eq!(response.headers()["x-seen-intercept"], "yes");
+    assert_eq!(response.text().await.unwrap(), "abcdef");
+
+    let _ = shutdown_tx.send(());
+    let _ = upstream_shutdown.send(());
+    assert!(handle.await.unwrap().is_ok());
+}
+
+#[cfg(feature = "scripting")]
+#[tokio::test]
+async fn reverse_proxy_runs_scripts_for_oversized_request_and_response() {
+    use std::io::Write;
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown) = start_echo_request_body_server().await;
+    let proxy_addr = reserve_loopback_addr().await;
+    let ca_dir = tempfile::tempdir().unwrap();
+    let mut script = tempfile::NamedTempFile::new().unwrap();
+    script
+        .write_all(
+            br#"
+            function on_request(req)
+                req.headers["x-script"] = "yes"
+                return req
+            end
+
+            function on_response(req, res)
+                res.headers["x-response-script"] = "yes"
+                return res
+            end
+            "#,
+        )
+        .unwrap();
+    script.flush().unwrap();
+
+    let (event_tx, _event_rx) = mpsc::channel::<ProxyEvent>(100);
+    let config = ProxyConfig {
+        addr: proxy_addr,
+        mode: ProxyMode::Reverse {
+            target: format!("http://{upstream_addr}").parse().unwrap(),
+        },
+        event_tx,
+        ca_dir: ca_dir.path().to_path_buf(),
+        intercept: None,
+        body_capture_limit: 4,
+        script_path: Some(script.path().to_path_buf()),
+        replay_rx: None,
+    };
+
+    let proxy = Proxy::new(config);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let handle = tokio::spawn(async move {
+        proxy
+            .start(async {
+                shutdown_rx.await.ok();
+            })
+            .await
+    });
+
+    wait_for_tcp(proxy_addr).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{proxy_addr}/scripted"))
+        .body("abcdef")
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), reqwest::StatusCode::CREATED);
+    assert_eq!(response.headers()["x-seen-script"], "yes");
+    assert_eq!(response.headers()["x-response-script"], "yes");
+    assert_eq!(response.text().await.unwrap(), "abcdef");
+
+    let _ = shutdown_tx.send(());
+    let _ = upstream_shutdown.send(());
     assert!(handle.await.unwrap().is_ok());
 }
 
@@ -213,6 +374,34 @@ async fn start_upstream_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()
     (addr, shutdown_tx)
 }
 
+async fn start_echo_request_body_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                result = listener.accept() => {
+                    let Ok((stream, _)) = result else {
+                        break;
+                    };
+                    tokio::spawn(async move {
+                        let io = TokioIo::new(stream);
+                        let service = service_fn(echo_request_body_response);
+                        let _ = hyper::server::conn::http1::Builder::new()
+                            .serve_connection(io, service)
+                            .await;
+                    });
+                }
+                _ = &mut shutdown_rx => break,
+            }
+        }
+    });
+
+    (addr, shutdown_tx)
+}
+
 async fn upstream_response(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let path = req.uri().path().to_owned();
     Ok(Response::builder()
@@ -220,4 +409,22 @@ async fn upstream_response(req: Request<Incoming>) -> Result<Response<Full<Bytes
         .header("x-upstream-path", path)
         .body(Full::new(Bytes::from_static(b"upstream response")))
         .unwrap())
+}
+
+async fn echo_request_body_response(
+    req: Request<Incoming>,
+) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    let script_header = req.headers().get("x-script").cloned();
+    let intercept_header = req.headers().get("x-intercept").cloned();
+    let body = req.into_body().collect().await?.to_bytes();
+
+    let mut builder = Response::builder().status(http::StatusCode::CREATED);
+    if let Some(value) = script_header {
+        builder = builder.header("x-seen-script", value);
+    }
+    if let Some(value) = intercept_header {
+        builder = builder.header("x-seen-intercept", value);
+    }
+
+    Ok(builder.body(Full::new(body)).unwrap())
 }


### PR DESCRIPTION
## What
Adds a configurable body capture limit (--body-capture-limit) and streams oversized request/response bodies through instead of buffering them completely.

This keeps proxy traffic intact while still giving capture, intercept, replay, and Lua hooks a capped body preview.

## Changelog
- [x] Added an entry under [Unreleased].

## Tests
- [x] Added coverage for body capture limits, oversized streaming, intercept behavior, Lua hooks, and CLI parsing.