### PR TITLE
Http2 proxy support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 
+- Accept HTTP/2 client connections in forward and reverse proxy modes while preserving HTTP/1.1 upstream forwarding invariants.
 - Emit visible flow events for Lua short-circuits, intercept drops, replay failures, and upstream proxy errors.
 
 ## [0.4.4] - 2026-05-01

--- a/proxyapi/Cargo.toml
+++ b/proxyapi/Cargo.toml
@@ -19,8 +19,8 @@ scripting = ["mlua"]
 
 [dependencies]
 mlua = { version = "0.11", features = ["lua54", "vendored", "send"], optional = true }
-hyper = { version = "1.9", features = ["http1", "server", "client"] }
-hyper-util = { version = "0.1", features = ["tokio", "server-auto", "client-legacy", "http1"] }
+hyper = { version = "1.9", features = ["http1", "http2", "server", "client"] }
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "client-legacy", "http1", "http2"] }
 http = "1.2"
 http-body-util = "0.1"
 bytes = "1.9"

--- a/proxyapi/src/ca/mod.rs
+++ b/proxyapi/src/ca/mod.rs
@@ -213,7 +213,7 @@ impl CertificateAuthority for Ssl {
             .with_no_client_auth()
             .with_single_cert(certs, private_key)?;
 
-        server_cfg.alpn_protocols = vec![b"http/1.1".to_vec()];
+        server_cfg.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
 
         let server_cfg = Arc::new(server_cfg);
 

--- a/proxyapi/src/proxy/forward.rs
+++ b/proxyapi/src/proxy/forward.rs
@@ -22,16 +22,45 @@ use crate::handler::{now_millis, CapturingHandler};
 use crate::rewind::Rewind;
 use crate::{HttpContext, HttpHandler, RequestOrResponse};
 
-use super::{is_benign_shutdown_error, Client};
+use super::{
+    is_benign_shutdown_error, prepare_upstream_request, prepare_upstream_upgrade_request,
+    sanitize_response_for_client, serve_auto_connection, BoxError, Client,
+};
 
-/// First bytes of an HTTP GET request.
-const HTTP_GET_PREFIX: &[u8; 4] = b"GET ";
+/// HTTP/2 prior-knowledge connection preface.
+const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+/// HTTP/1 request method prefixes used for CONNECT tunnel protocol sniffing.
+const HTTP1_METHOD_PREFIXES: &[&[u8]] = &[
+    b"CONNECT ",
+    b"DELETE ",
+    b"GET ",
+    b"HEAD ",
+    b"OPTIONS ",
+    b"PATCH ",
+    b"POST ",
+    b"PUT ",
+    b"TRACE ",
+];
 /// TLS record content type: Handshake.
 const TLS_RECORD_HANDSHAKE: u8 = 0x16;
 /// TLS major version byte (SSLv3 / TLS 1.x).
 const TLS_VERSION_MAJOR: u8 = 0x03;
 /// Maximum payload size captured per WebSocket frame.
 const MAX_WS_FRAME_PAYLOAD: Option<usize> = crate::handler::DEFAULT_BODY_CAPTURE_LIMIT;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum StreamProtocol {
+    Http,
+    Tls,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum TunnelRequestError {
+    MissingHost,
+    InvalidHost,
+    InvalidUri,
+}
 
 /// Returns true when the request carries WebSocket upgrade tokens.
 fn is_websocket_upgrade<B>(req: &Request<B>) -> bool {
@@ -58,14 +87,12 @@ pub async fn handle_connection(
 ) {
     let io = TokioIo::new(stream);
 
-    let service = service_fn(move |mut req: Request<hyper::body::Incoming>| {
-        let mut handler = handler.clone();
+    let service = service_fn(move |req: Request<hyper::body::Incoming>| {
+        let handler = handler.clone();
         let ca = Arc::clone(&ca);
         let client = Arc::clone(&client);
 
         async move {
-            let ctx = HttpContext { remote_addr };
-
             // Direct request to the proxy itself (relative URI, no host).
             // Serves the cert download page at http://localhost:PORT/
             if req.uri().host().is_none() && !req.uri().path().is_empty() {
@@ -83,82 +110,12 @@ pub async fn handle_connection(
                 return process_connect(req, handler, ca, client, remote_addr, listen_addr);
             }
 
-            // Extract WebSocket upgrade future BEFORE handle_request consumes req.
-            let is_ws = is_websocket_upgrade(&req);
-            let client_on_upgrade = if is_ws {
-                Some(hyper::upgrade::on(&mut req))
-            } else {
-                None
-            };
-
-            let req = match handler.handle_request(&ctx, req).await {
-                RequestOrResponse::Request(req) => req,
-                RequestOrResponse::Response(res) => return Ok(res),
-            };
-
-            match client.request(normalize_request(req)).await {
-                Ok(mut res) => {
-                    if is_ws && res.status() == hyper::StatusCode::SWITCHING_PROTOCOLS {
-                        let server_on_upgrade = hyper::upgrade::on(&mut res);
-                        let (parts, _body) = res.into_parts();
-
-                        let ws_response = ProxiedResponse::new(
-                            parts.status,
-                            parts.version,
-                            parts.headers.clone(),
-                            Bytes::new(),
-                            now_millis(),
-                        );
-
-                        let conn_id = handler
-                            .take_pending_id()
-                            .unwrap_or_else(crate::event::next_id);
-                        if let Some(captured_req) = handler.take_captured_request() {
-                            handler.send_event(ProxyEvent::WebSocketConnected {
-                                id: conn_id,
-                                request: Box::new(captured_req),
-                                response: Box::new(ws_response),
-                            });
-                        }
-
-                        if let Some(client_fut) = client_on_upgrade {
-                            let event_tx = handler.event_tx_clone();
-                            tokio::spawn(async move {
-                                pump_websocket_frames(
-                                    conn_id,
-                                    client_fut,
-                                    server_on_upgrade,
-                                    event_tx,
-                                )
-                                .await;
-                            });
-                        }
-
-                        Ok(Response::from_parts(parts, body::empty()))
-                    } else {
-                        Ok(handler.handle_upstream_response(res).await)
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("Client request error: {e}");
-                    Ok(handler.synthetic_response(
-                        http::StatusCode::BAD_GATEWAY,
-                        http::HeaderMap::new(),
-                        Bytes::from_static(b"Bad Gateway"),
-                    ))
-                }
-            }
+            forward_http_request(req, handler, client, remote_addr).await
         }
     });
 
-    if let Err(e) = hyper::server::conn::http1::Builder::new()
-        .preserve_header_case(true)
-        .title_case_headers(true)
-        .serve_connection(io, service)
-        .with_upgrades()
-        .await
-    {
-        if !is_benign_shutdown_error(&e) {
+    if let Err(e) = serve_auto_connection(io, service).await {
+        if !is_benign_shutdown_error(e.as_ref()) {
             tracing::debug!("Connection error: {e}");
         }
     }
@@ -191,86 +148,89 @@ fn process_connect(
         match hyper::upgrade::on(req).await {
             Ok(upgraded) => {
                 let mut upgraded = TokioIo::new(upgraded);
-                let mut buffer = [0u8; 4];
-                let bytes_read = match upgraded.read(&mut buffer).await {
-                    Ok(n) => n,
+                let (protocol, buffered) = match sniff_stream_protocol(&mut upgraded).await {
+                    Ok(result) => result,
                     Err(e) => {
                         tracing::error!("Failed to read from upgraded connection: {e}");
                         return;
                     }
                 };
 
-                let upgraded =
-                    Rewind::new_buffered(upgraded, Bytes::copy_from_slice(&buffer[..bytes_read]));
+                let upgraded = Rewind::new_buffered(upgraded, buffered.clone());
 
-                if buffer == *HTTP_GET_PREFIX {
-                    if let Err(e) = serve_stream(
-                        upgraded,
-                        Scheme::HTTP,
-                        handler,
-                        ca,
-                        client,
-                        remote_addr,
-                        listen_addr,
-                    )
-                    .await
-                    {
-                        tracing::debug!("HTTP connect error: {e}");
-                    }
-                } else if buffer[0] == TLS_RECORD_HANDSHAKE && buffer[1] == TLS_VERSION_MAJOR {
-                    let server_config = match ca.gen_server_config(&authority).await {
-                        Ok(cfg) => cfg,
-                        Err(e) => {
-                            tracing::error!(
-                                "Failed to generate server config for {authority}: {e}"
-                            );
-                            return;
-                        }
-                    };
-                    let stream = match TlsAcceptor::from(server_config).accept(upgraded).await {
-                        Ok(stream) => stream,
-                        Err(e) => {
-                            tracing::debug!("Failed to establish TLS connection: {e}");
-                            return;
-                        }
-                    };
-
-                    if let Err(e) = serve_stream(
-                        stream,
-                        Scheme::HTTPS,
-                        handler,
-                        ca,
-                        client,
-                        remote_addr,
-                        listen_addr,
-                    )
-                    .await
-                    {
-                        if !is_benign_shutdown_error(&*e) {
-                            tracing::warn!("HTTPS connect error for {authority}: {e}");
+                match protocol {
+                    StreamProtocol::Http => {
+                        if let Err(e) = serve_stream(
+                            upgraded,
+                            Scheme::HTTP,
+                            handler,
+                            ca,
+                            client,
+                            remote_addr,
+                            listen_addr,
+                        )
+                        .await
+                        {
+                            tracing::debug!("HTTP connect error: {e}");
                         }
                     }
-                } else {
-                    tracing::debug!(
-                        "Unknown protocol, read '{:02X?}' from upgraded connection",
-                        &buffer[..bytes_read]
-                    );
+                    StreamProtocol::Tls => {
+                        let server_config = match ca.gen_server_config(&authority).await {
+                            Ok(cfg) => cfg,
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to generate server config for {authority}: {e}"
+                                );
+                                return;
+                            }
+                        };
+                        let stream = match TlsAcceptor::from(server_config).accept(upgraded).await {
+                            Ok(stream) => stream,
+                            Err(e) => {
+                                tracing::debug!("Failed to establish TLS connection: {e}");
+                                return;
+                            }
+                        };
 
-                    let authority_str = authority.as_str();
-                    let mut server = match TcpStream::connect(authority_str).await {
-                        Ok(server) => server,
-                        Err(e) => {
-                            tracing::debug!("Failed to connect to {authority_str}: {e}");
-                            return;
+                        if let Err(e) = serve_stream(
+                            stream,
+                            Scheme::HTTPS,
+                            handler,
+                            ca,
+                            client,
+                            remote_addr,
+                            listen_addr,
+                        )
+                        .await
+                        {
+                            if !is_benign_shutdown_error(&*e) {
+                                tracing::warn!("HTTPS connect error for {authority}: {e}");
+                            }
                         }
-                    };
-
-                    let mut upgraded = upgraded;
-                    if let Err(e) = tokio::io::copy_bidirectional(&mut upgraded, &mut server).await
-                    {
+                    }
+                    StreamProtocol::Unknown => {
                         tracing::debug!(
-                            "Failed to tunnel unknown protocol to {authority_str}: {e}"
+                            "Unknown protocol, read '{:02X?}' from upgraded connection",
+                            buffered.as_ref()
                         );
+
+                        let authority_str = authority.as_str();
+                        let mut server = match TcpStream::connect(authority_str).await {
+                            Ok(server) => server,
+                            Err(e) => {
+                                tracing::debug!("Failed to connect to {authority_str}: {e}");
+                                return;
+                            }
+                        };
+
+                        let mut upgraded = upgraded;
+                        if let Err(e) =
+                            tokio::io::copy_bidirectional(&mut upgraded, &mut server).await
+                        {
+                            tracing::debug!(
+                                "Failed to tunnel unknown protocol to {authority_str}: {e}"
+                            );
+                        }
                     }
                 }
             }
@@ -281,7 +241,7 @@ fn process_connect(
     Ok(Response::new(body::empty()))
 }
 
-/// Serve HTTP/1.1 requests over an already-established stream (plain or TLS).
+/// Serve HTTP requests over an already-established stream (plain or TLS).
 ///
 /// Each request is passed through the [`CapturingHandler`] for inspection before
 /// being forwarded to the upstream server via `client`.
@@ -293,65 +253,23 @@ async fn serve_stream<I>(
     client: Arc<Client>,
     remote_addr: SocketAddr,
     listen_addr: SocketAddr,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+) -> Result<(), BoxError>
 where
     I: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let io = TokioIo::new(stream);
 
     let service = service_fn(move |mut req: Request<hyper::body::Incoming>| {
-        let mut handler = handler.clone();
+        let handler = handler.clone();
         let ca = Arc::clone(&ca);
         let client = Arc::clone(&client);
         let scheme = scheme.clone();
 
         async move {
-            let ctx = HttpContext { remote_addr };
-
-            // Reconstruct full URI with scheme + authority from Host header
-            if req.version() == hyper::Version::HTTP_10 || req.version() == hyper::Version::HTTP_11
-            {
-                let (mut parts, body) = req.into_parts();
-
-                let host = if let Some(h) = parts.headers.get(hyper::header::HOST) {
-                    h.as_bytes()
-                } else {
-                    tracing::warn!("Request missing Host header");
-                    return Ok(Response::builder()
-                        .status(400)
-                        .body(body::full(Bytes::from("Bad Request: missing Host header")))
-                        .unwrap_or_else(|_| Response::new(body::empty())));
-                };
-
-                let authority = match Authority::try_from(host) {
-                    Ok(a) => a,
-                    Err(e) => {
-                        tracing::warn!("Failed to parse authority from Host header: {e}");
-                        return Ok(Response::builder()
-                            .status(400)
-                            .body(body::full(Bytes::from("Bad Request: invalid Host header")))
-                            .unwrap_or_else(|_| Response::new(body::empty())));
-                    }
-                };
-
-                parts.uri = {
-                    let mut uri_parts = parts.uri.into_parts();
-                    uri_parts.scheme = Some(scheme);
-                    uri_parts.authority = Some(authority);
-                    match Uri::from_parts(uri_parts) {
-                        Ok(uri) => uri,
-                        Err(e) => {
-                            tracing::warn!("Failed to build URI: {e}");
-                            return Ok(Response::builder()
-                                .status(400)
-                                .body(body::full(Bytes::from("Bad Request: invalid URI")))
-                                .unwrap_or_else(|_| Response::new(body::empty())));
-                        }
-                    }
-                };
-
-                req = Request::from_parts(parts, body);
-            }
+            req = match reconstruct_tunnel_uri(req, scheme) {
+                Ok(req) => req,
+                Err(e) => return Ok(e.into_response()),
+            };
 
             // Check for proxel.ar cert request (inside CONNECT tunnel)
             if cert_server::is_cert_request(&req) {
@@ -359,107 +277,224 @@ where
                 return Ok::<_, hyper::Error>(resp);
             }
 
-            // Extract WebSocket upgrade future BEFORE handle_request consumes req.
-            let is_ws = is_websocket_upgrade(&req);
-            let client_on_upgrade = if is_ws {
-                Some(hyper::upgrade::on(&mut req))
-            } else {
-                None
-            };
-
-            let req = match handler.handle_request(&ctx, req).await {
-                RequestOrResponse::Request(req) => req,
-                RequestOrResponse::Response(res) => return Ok(res),
-            };
-
-            match client.request(normalize_request(req)).await {
-                Ok(mut res) => {
-                    if is_ws && res.status() == hyper::StatusCode::SWITCHING_PROTOCOLS {
-                        let server_on_upgrade = hyper::upgrade::on(&mut res);
-                        let (parts, _body) = res.into_parts();
-
-                        let ws_response = ProxiedResponse::new(
-                            parts.status,
-                            parts.version,
-                            parts.headers.clone(),
-                            Bytes::new(),
-                            now_millis(),
-                        );
-
-                        let conn_id = handler
-                            .take_pending_id()
-                            .unwrap_or_else(crate::event::next_id);
-                        if let Some(captured_req) = handler.take_captured_request() {
-                            handler.send_event(ProxyEvent::WebSocketConnected {
-                                id: conn_id,
-                                request: Box::new(captured_req),
-                                response: Box::new(ws_response),
-                            });
-                        }
-
-                        if let Some(client_fut) = client_on_upgrade {
-                            let event_tx = handler.event_tx_clone();
-                            tokio::spawn(async move {
-                                pump_websocket_frames(
-                                    conn_id,
-                                    client_fut,
-                                    server_on_upgrade,
-                                    event_tx,
-                                )
-                                .await;
-                            });
-                        }
-
-                        Ok(Response::from_parts(parts, body::empty()))
-                    } else {
-                        Ok(handler.handle_upstream_response(res).await)
-                    }
-                }
-                Err(e) => {
-                    tracing::error!("Client request error: {e}");
-                    Ok(handler.synthetic_response(
-                        http::StatusCode::BAD_GATEWAY,
-                        http::HeaderMap::new(),
-                        Bytes::from_static(b"Bad Gateway"),
-                    ))
-                }
-            }
+            forward_http_request(req, handler, client, remote_addr).await
         }
     });
 
-    hyper::server::conn::http1::Builder::new()
-        .preserve_header_case(true)
-        .title_case_headers(true)
-        .serve_connection(io, service)
-        .with_upgrades()
-        .await
-        .map_err(Into::into)
+    serve_auto_connection(io, service).await
 }
 
-/// Strip hop-by-hop artifacts before forwarding a request upstream.
-///
-/// Removes the `Host` header (hyper sets it from the URI), joins duplicate
-/// `Cookie` headers into a single value, and pins the version to HTTP/1.1.
-fn normalize_request(mut req: Request<ProxyBody>) -> Request<ProxyBody> {
-    req.headers_mut().remove(hyper::header::HOST);
+async fn forward_http_request(
+    mut req: Request<hyper::body::Incoming>,
+    mut handler: CapturingHandler,
+    client: Arc<Client>,
+    remote_addr: SocketAddr,
+) -> Result<Response<ProxyBody>, hyper::Error> {
+    let client_version = req.version();
+    let ctx = HttpContext { remote_addr };
 
-    if let http::header::Entry::Occupied(mut cookies) =
-        req.headers_mut().entry(hyper::header::COOKIE)
-    {
-        let joined_cookies = bstr::join(b"; ", cookies.iter());
-        match joined_cookies.try_into() {
-            Ok(value) => {
-                cookies.insert(value);
+    // Extract WebSocket upgrade future before handle_request consumes req.
+    let is_ws = is_websocket_upgrade(&req);
+    let client_on_upgrade = if is_ws {
+        Some(hyper::upgrade::on(&mut req))
+    } else {
+        None
+    };
+
+    let req = match handler.handle_request(&ctx, req).await {
+        RequestOrResponse::Request(req) => req,
+        RequestOrResponse::Response(mut res) => {
+            sanitize_response_for_client(&mut res, client_version);
+            return Ok(res);
+        }
+    };
+
+    let upstream_req = if is_ws {
+        prepare_upstream_upgrade_request(req)
+    } else {
+        prepare_upstream_request(req)
+    };
+
+    match client.request(upstream_req).await {
+        Ok(res) => {
+            if is_ws && res.status() == hyper::StatusCode::SWITCHING_PROTOCOLS {
+                return Ok(upgrade_websocket_response(res, handler, client_on_upgrade));
             }
-            Err(e) => {
-                tracing::warn!("Failed to join cookies, removing header: {e}");
-                cookies.remove();
-            }
+
+            let mut res = handler.handle_upstream_response(res).await;
+            sanitize_response_for_client(&mut res, client_version);
+            Ok(res)
+        }
+        Err(e) => {
+            tracing::error!("Client request error: {e}");
+            let mut res = handler.synthetic_response(
+                http::StatusCode::BAD_GATEWAY,
+                http::HeaderMap::new(),
+                Bytes::from_static(b"Bad Gateway"),
+            );
+            sanitize_response_for_client(&mut res, client_version);
+            Ok(res)
         }
     }
+}
 
-    *req.version_mut() = hyper::Version::HTTP_11;
-    req
+fn upgrade_websocket_response(
+    mut res: Response<hyper::body::Incoming>,
+    mut handler: CapturingHandler,
+    client_on_upgrade: Option<hyper::upgrade::OnUpgrade>,
+) -> Response<ProxyBody> {
+    let server_on_upgrade = hyper::upgrade::on(&mut res);
+    let (parts, _body) = res.into_parts();
+
+    let ws_response = ProxiedResponse::new(
+        parts.status,
+        parts.version,
+        parts.headers.clone(),
+        Bytes::new(),
+        now_millis(),
+    );
+
+    let conn_id = handler
+        .take_pending_id()
+        .unwrap_or_else(crate::event::next_id);
+    if let Some(captured_req) = handler.take_captured_request() {
+        handler.send_event(ProxyEvent::WebSocketConnected {
+            id: conn_id,
+            request: Box::new(captured_req),
+            response: Box::new(ws_response),
+        });
+    }
+
+    if let Some(client_fut) = client_on_upgrade {
+        let event_tx = handler.event_tx_clone();
+        tokio::spawn(async move {
+            pump_websocket_frames(conn_id, client_fut, server_on_upgrade, event_tx).await;
+        });
+    }
+
+    Response::from_parts(parts, body::empty())
+}
+
+fn reconstruct_tunnel_uri(
+    req: Request<hyper::body::Incoming>,
+    scheme: Scheme,
+) -> Result<Request<hyper::body::Incoming>, TunnelRequestError> {
+    let (mut parts, body) = req.into_parts();
+    let authority = tunnel_authority(&parts)?;
+
+    let mut uri_parts = parts.uri.into_parts();
+    uri_parts.scheme = Some(scheme);
+    uri_parts.authority = Some(authority);
+    parts.uri = Uri::from_parts(uri_parts).map_err(|e| {
+        tracing::warn!("Failed to build URI: {e}");
+        TunnelRequestError::InvalidUri
+    })?;
+
+    Ok(Request::from_parts(parts, body))
+}
+
+fn tunnel_authority(parts: &http::request::Parts) -> Result<Authority, TunnelRequestError> {
+    if let Some(authority) = parts.uri.authority() {
+        return Ok(authority.clone());
+    }
+
+    let Some(host) = parts.headers.get(hyper::header::HOST) else {
+        tracing::warn!("Request missing Host header");
+        return Err(TunnelRequestError::MissingHost);
+    };
+
+    Authority::try_from(host.as_bytes()).map_err(|e| {
+        tracing::warn!("Failed to parse authority from Host header: {e}");
+        TunnelRequestError::InvalidHost
+    })
+}
+
+impl TunnelRequestError {
+    fn into_response(self) -> Response<ProxyBody> {
+        Response::builder()
+            .status(http::StatusCode::BAD_REQUEST)
+            .body(body::full(Bytes::from_static(self.message().as_bytes())))
+            .unwrap_or_else(|_| Response::new(body::empty()))
+    }
+
+    const fn message(self) -> &'static str {
+        match self {
+            Self::MissingHost => "Bad Request: missing Host header",
+            Self::InvalidHost => "Bad Request: invalid Host header",
+            Self::InvalidUri => "Bad Request: invalid URI",
+        }
+    }
+}
+
+async fn sniff_stream_protocol<I>(stream: &mut I) -> std::io::Result<(StreamProtocol, Bytes)>
+where
+    I: AsyncRead + Unpin,
+{
+    let mut buffer = [0u8; H2_PREFACE.len()];
+    let mut filled = 0;
+
+    loop {
+        let bytes_read = stream.read(&mut buffer[filled..]).await?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        filled += bytes_read;
+        let prefix = &buffer[..filled];
+
+        if is_tls_handshake(prefix) {
+            return Ok((StreamProtocol::Tls, Bytes::copy_from_slice(prefix)));
+        }
+        if is_h2_preface(prefix) || is_http1_request(prefix) {
+            return Ok((StreamProtocol::Http, Bytes::copy_from_slice(prefix)));
+        }
+        if filled < buffer.len() && could_be_known_protocol(prefix) {
+            continue;
+        }
+
+        return Ok((StreamProtocol::Unknown, Bytes::copy_from_slice(prefix)));
+    }
+
+    Ok((
+        classify_buffered_protocol(&buffer[..filled]),
+        Bytes::copy_from_slice(&buffer[..filled]),
+    ))
+}
+
+fn classify_buffered_protocol(buffered: &[u8]) -> StreamProtocol {
+    if is_tls_handshake(buffered) {
+        StreamProtocol::Tls
+    } else if is_h2_preface(buffered) || is_http1_request(buffered) {
+        StreamProtocol::Http
+    } else {
+        StreamProtocol::Unknown
+    }
+}
+
+fn is_tls_handshake(buffered: &[u8]) -> bool {
+    buffered.len() >= 2 && buffered[0] == TLS_RECORD_HANDSHAKE && buffered[1] == TLS_VERSION_MAJOR
+}
+
+fn is_h2_preface(buffered: &[u8]) -> bool {
+    buffered == H2_PREFACE
+}
+
+fn is_http1_request(buffered: &[u8]) -> bool {
+    HTTP1_METHOD_PREFIXES
+        .iter()
+        .any(|method| buffered.starts_with(method))
+}
+
+fn could_be_known_protocol(buffered: &[u8]) -> bool {
+    is_partial_tls_handshake(buffered)
+        || H2_PREFACE.starts_with(buffered)
+        || HTTP1_METHOD_PREFIXES
+            .iter()
+            .any(|method| method.starts_with(buffered))
+}
+
+fn is_partial_tls_handshake(buffered: &[u8]) -> bool {
+    buffered == [TLS_RECORD_HANDSHAKE]
 }
 
 /// Await both WebSocket upgrade futures, wrap the raw streams in tungstenite
@@ -565,7 +600,7 @@ pub(crate) async fn handle_replay(
     let Some(fwd_req) = handler.handle_replayed_request(req).await else {
         return;
     };
-    match client.request(normalize_request(fwd_req)).await {
+    match client.request(prepare_upstream_request(fwd_req)).await {
         Ok(res) => {
             handler.record_upstream_response(res).await;
         }
@@ -612,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    fn normalize_request_removes_host_joins_cookies_and_pins_http11() {
+    fn prepare_upstream_request_removes_host_joins_cookies_and_pins_http11() {
         let req = Request::builder()
             .method(Method::GET)
             .uri("http://upstream.test/path")
@@ -623,7 +658,7 @@ mod tests {
             .body(body::empty())
             .unwrap();
 
-        let req = normalize_request(req);
+        let req = prepare_upstream_request(req);
 
         assert!(!req.headers().contains_key(hyper::header::HOST));
         assert_eq!(
@@ -635,6 +670,35 @@ mod tests {
             1
         );
         assert_eq!(req.version(), hyper::Version::HTTP_11);
+    }
+
+    #[test]
+    fn classify_buffered_protocol_detects_http2_preface() {
+        assert_eq!(classify_buffered_protocol(H2_PREFACE), StreamProtocol::Http);
+    }
+
+    #[test]
+    fn classify_buffered_protocol_detects_http1_methods_and_tls() {
+        assert_eq!(
+            classify_buffered_protocol(b"POST /upload HTTP/1.1\r\n"),
+            StreamProtocol::Http
+        );
+        assert_eq!(
+            classify_buffered_protocol(&[TLS_RECORD_HANDSHAKE, TLS_VERSION_MAJOR, 0x03, 0x00]),
+            StreamProtocol::Tls
+        );
+        assert_eq!(
+            classify_buffered_protocol(b"\x01\x02\x03"),
+            StreamProtocol::Unknown
+        );
+    }
+
+    #[test]
+    fn could_be_known_protocol_waits_for_partial_prefixes() {
+        assert!(could_be_known_protocol(b"P"));
+        assert!(could_be_known_protocol(b"PRI * HTTP/2.0\r\n"));
+        assert!(could_be_known_protocol(&[TLS_RECORD_HANDSHAKE]));
+        assert!(!could_be_known_protocol(b"NOPE"));
     }
 
     #[tokio::test]

--- a/proxyapi/src/proxy/mod.rs
+++ b/proxyapi/src/proxy/mod.rs
@@ -1,11 +1,19 @@
 pub(crate) mod forward;
 pub(crate) mod reverse;
 
-use std::{future::Future, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{error::Error as StdError, future::Future, net::SocketAddr, path::PathBuf, sync::Arc};
 
-use hyper::Uri;
+use hyper::body::{Body as HttpBody, Incoming};
+use hyper::header::{
+    HeaderName, CONNECTION, COOKIE, HOST, PROXY_AUTHENTICATE, PROXY_AUTHORIZATION, TE,
+    TRANSFER_ENCODING, UPGRADE,
+};
+use hyper::rt::{Read, Write};
+use hyper::service::Service;
+use hyper::{HeaderMap, Request, Response, Uri};
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
+use hyper_util::server::conn::auto;
 use proxyapi_models::ProxiedRequest;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
@@ -22,6 +30,10 @@ use crate::scripting::ScriptEngine;
 /// Shared HTTP(S) client type used by both forward and reverse proxy.
 pub(crate) type Client =
     hyper_util::client::legacy::Client<hyper_rustls::HttpsConnector<HttpConnector>, ProxyBody>;
+pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
+
+const KEEP_ALIVE: HeaderName = HeaderName::from_static("keep-alive");
+const PROXY_CONNECTION: HeaderName = HeaderName::from_static("proxy-connection");
 
 /// Check if an error is a benign "shutting down" or "connection closed" error.
 ///
@@ -30,6 +42,105 @@ pub(crate) type Client =
 pub(crate) fn is_benign_shutdown_error(e: &dyn std::error::Error) -> bool {
     let msg = e.to_string();
     msg.contains("shutting down") || msg.contains("connection was not closed cleanly")
+}
+
+/// Serve an HTTP connection using Hyper's protocol auto-detection.
+///
+/// The upgrade-capable path is required for HTTP/1 CONNECT, WebSocket upgrades,
+/// and Hyper's HTTP/2 CONNECT upgrade adapter.
+pub(crate) async fn serve_auto_connection<I, S, B>(io: I, service: S) -> Result<(), BoxError>
+where
+    I: Read + Write + Unpin + Send + 'static,
+    S: Service<Request<Incoming>, Response = Response<B>>,
+    S::Future: 'static,
+    S::Error: Into<BoxError>,
+    B: HttpBody + 'static,
+    B::Error: Into<BoxError>,
+    TokioExecutor: auto::HttpServerConnExec<S::Future, B>,
+{
+    let builder = auto::Builder::new(TokioExecutor::new())
+        .preserve_header_case(true)
+        .title_case_headers(true);
+
+    builder.serve_connection_with_upgrades(io, service).await
+}
+
+/// Prepare a captured request for the upstream HTTP/1.1 client.
+///
+/// This centralizes the proxy's existing invariants and strips hop-by-hop
+/// metadata that must not be forwarded across protocol boundaries.
+pub(crate) fn prepare_upstream_request(mut req: Request<ProxyBody>) -> Request<ProxyBody> {
+    strip_hop_by_hop_headers(req.headers_mut());
+    req.headers_mut().remove(HOST);
+    req.headers_mut().remove(PROXY_AUTHORIZATION);
+    req.headers_mut().remove(TE);
+    join_cookie_headers(req.headers_mut());
+    *req.version_mut() = hyper::Version::HTTP_11;
+    req
+}
+
+/// Prepare an HTTP/1.1 protocol-upgrade request for the upstream client.
+///
+/// Upgrade handshakes intentionally keep `Connection` and `Upgrade`; stripping
+/// them would turn WebSocket forwarding into an ordinary HTTP request.
+pub(crate) fn prepare_upstream_upgrade_request(mut req: Request<ProxyBody>) -> Request<ProxyBody> {
+    req.headers_mut().remove(HOST);
+    req.headers_mut().remove(PROXY_AUTHORIZATION);
+    join_cookie_headers(req.headers_mut());
+    *req.version_mut() = hyper::Version::HTTP_11;
+    req
+}
+
+/// Remove response headers that are illegal on HTTP/2 connections.
+fn sanitize_response_for_http2<B>(res: &mut Response<B>) {
+    strip_hop_by_hop_headers(res.headers_mut());
+    res.headers_mut().remove(PROXY_AUTHENTICATE);
+    res.headers_mut().remove(TE);
+}
+
+pub(crate) fn sanitize_response_for_client<B>(res: &mut Response<B>, version: hyper::Version) {
+    if version == hyper::Version::HTTP_2 {
+        sanitize_response_for_http2(res);
+    }
+}
+
+fn join_cookie_headers(headers: &mut HeaderMap) {
+    if let http::header::Entry::Occupied(mut cookies) = headers.entry(COOKIE) {
+        let joined_cookies = bstr::join(b"; ", cookies.iter());
+        match joined_cookies.try_into() {
+            Ok(value) => {
+                cookies.insert(value);
+            }
+            Err(e) => {
+                tracing::warn!("Failed to join cookies, removing header: {e}");
+                cookies.remove();
+            }
+        }
+    }
+}
+
+fn strip_hop_by_hop_headers(headers: &mut HeaderMap) {
+    let connection_tokens = connection_tokens(headers);
+    headers.remove(CONNECTION);
+
+    for name in connection_tokens {
+        headers.remove(name);
+    }
+
+    headers.remove(KEEP_ALIVE);
+    headers.remove(PROXY_CONNECTION);
+    headers.remove(TRANSFER_ENCODING);
+    headers.remove(UPGRADE);
+}
+
+fn connection_tokens(headers: &HeaderMap) -> Vec<HeaderName> {
+    headers
+        .get_all(CONNECTION)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .filter_map(|token| HeaderName::from_bytes(token.trim().as_bytes()).ok())
+        .collect()
 }
 
 /// Configuration for creating a [`Proxy`].
@@ -252,5 +363,104 @@ mod tests {
             tokio::time::timeout(std::time::Duration::from_millis(10), recv_replay(&mut rx)).await;
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn prepare_upstream_request_preserves_invariants_and_strips_hop_by_hop_headers() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("http://upstream.test/path")
+            .version(Version::HTTP_2)
+            .header(HOST, "wrong-host.test")
+            .header(COOKIE, "a=1")
+            .header(COOKIE, "b=2")
+            .header(CONNECTION, "x-remove, keep-alive")
+            .header("x-remove", "yes")
+            .header(KEEP_ALIVE, "timeout=5")
+            .header(PROXY_CONNECTION, "keep-alive")
+            .header(TRANSFER_ENCODING, "chunked")
+            .header(UPGRADE, "websocket")
+            .header(PROXY_AUTHORIZATION, "Basic secret")
+            .header(TE, "trailers")
+            .body(crate::body::empty())
+            .unwrap();
+
+        let req = prepare_upstream_request(req);
+
+        assert_eq!(req.version(), Version::HTTP_11);
+        assert!(!req.headers().contains_key(HOST));
+        assert!(!req.headers().contains_key(CONNECTION));
+        assert!(!req.headers().contains_key("x-remove"));
+        assert!(!req.headers().contains_key(KEEP_ALIVE));
+        assert!(!req.headers().contains_key(PROXY_CONNECTION));
+        assert!(!req.headers().contains_key(TRANSFER_ENCODING));
+        assert!(!req.headers().contains_key(UPGRADE));
+        assert!(!req.headers().contains_key(PROXY_AUTHORIZATION));
+        assert!(!req.headers().contains_key(TE));
+        assert_eq!(
+            req.headers().get_all(COOKIE).iter().count(),
+            1,
+            "duplicate Cookie headers should be collapsed"
+        );
+        assert_eq!(req.headers()[COOKIE], "a=1; b=2");
+    }
+
+    #[test]
+    fn prepare_upstream_upgrade_request_preserves_upgrade_headers() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("http://upstream.test/ws")
+            .version(Version::HTTP_2)
+            .header(HOST, "wrong-host.test")
+            .header(CONNECTION, "Upgrade")
+            .header(UPGRADE, "websocket")
+            .header(PROXY_AUTHORIZATION, "Basic secret")
+            .body(crate::body::empty())
+            .unwrap();
+
+        let req = prepare_upstream_upgrade_request(req);
+
+        assert_eq!(req.version(), Version::HTTP_11);
+        assert!(!req.headers().contains_key(HOST));
+        assert!(!req.headers().contains_key(PROXY_AUTHORIZATION));
+        assert_eq!(req.headers()[CONNECTION], "Upgrade");
+        assert_eq!(req.headers()[UPGRADE], "websocket");
+    }
+
+    #[test]
+    fn sanitize_response_for_http2_strips_connection_metadata() {
+        let mut response = Response::builder()
+            .status(http::StatusCode::OK)
+            .header(CONNECTION, "x-remove, upgrade")
+            .header("x-remove", "yes")
+            .header(KEEP_ALIVE, "timeout=5")
+            .header(PROXY_CONNECTION, "keep-alive")
+            .header(TRANSFER_ENCODING, "chunked")
+            .header(UPGRADE, "websocket")
+            .header(PROXY_AUTHENTICATE, "Basic")
+            .header(TE, "trailers")
+            .body(crate::body::empty())
+            .unwrap();
+
+        sanitize_response_for_http2(&mut response);
+
+        assert!(!response.headers().contains_key(CONNECTION));
+        assert!(!response.headers().contains_key("x-remove"));
+        assert!(!response.headers().contains_key(KEEP_ALIVE));
+        assert!(!response.headers().contains_key(PROXY_CONNECTION));
+        assert!(!response.headers().contains_key(TRANSFER_ENCODING));
+        assert!(!response.headers().contains_key(UPGRADE));
+        assert!(!response.headers().contains_key(PROXY_AUTHENTICATE));
+        assert!(!response.headers().contains_key(TE));
+    }
+
+    #[test]
+    fn connection_tokens_ignores_invalid_header_names() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONNECTION, "x-valid, bad header".parse().unwrap());
+
+        let tokens = connection_tokens(&headers);
+
+        assert_eq!(tokens, vec![HeaderName::from_static("x-valid")]);
     }
 }

--- a/proxyapi/src/proxy/reverse.rs
+++ b/proxyapi/src/proxy/reverse.rs
@@ -11,7 +11,10 @@ use crate::body::ProxyBody;
 use crate::handler::CapturingHandler;
 use crate::{HttpContext, HttpHandler, RequestOrResponse};
 
-use super::{is_benign_shutdown_error, Client};
+use super::{
+    is_benign_shutdown_error, prepare_upstream_request, sanitize_response_for_client,
+    serve_auto_connection, Client,
+};
 
 pub async fn handle_connection(
     stream: TcpStream,
@@ -28,11 +31,15 @@ pub async fn handle_connection(
         let target = target.clone();
 
         async move {
+            let client_version = req.version();
             let ctx = HttpContext { remote_addr };
 
             let req = match handler.handle_request(&ctx, req).await {
                 RequestOrResponse::Request(req) => req,
-                RequestOrResponse::Response(res) => return Ok::<_, hyper::Error>(res),
+                RequestOrResponse::Response(mut res) => {
+                    sanitize_response_for_client(&mut res, client_version);
+                    return Ok::<_, hyper::Error>(res);
+                }
             };
 
             // Rewrite URI to target, preserving path and query
@@ -48,28 +55,28 @@ pub async fn handle_connection(
                 }
             };
 
-            match client.request(req).await {
-                Ok(res) => Ok(handler.handle_upstream_response(res).await),
+            match client.request(prepare_upstream_request(req)).await {
+                Ok(res) => {
+                    let mut res = handler.handle_upstream_response(res).await;
+                    sanitize_response_for_client(&mut res, client_version);
+                    Ok(res)
+                }
                 Err(e) => {
                     tracing::error!("Reverse proxy error: {e}");
-                    Ok(handler.synthetic_response(
+                    let mut res = handler.synthetic_response(
                         http::StatusCode::BAD_GATEWAY,
                         http::HeaderMap::new(),
                         Bytes::from_static(b"Bad Gateway"),
-                    ))
+                    );
+                    sanitize_response_for_client(&mut res, client_version);
+                    Ok(res)
                 }
             }
         }
     });
 
-    if let Err(e) = hyper::server::conn::http1::Builder::new()
-        .preserve_header_case(true)
-        .title_case_headers(true)
-        .serve_connection(io, service)
-        .with_upgrades()
-        .await
-    {
-        if !is_benign_shutdown_error(&e) {
+    if let Err(e) = serve_auto_connection(io, service).await {
+        if !is_benign_shutdown_error(e.as_ref()) {
             tracing::debug!("Reverse proxy connection error: {e}");
         }
     }

--- a/proxyapi/tests/cert_authority.rs
+++ b/proxyapi/tests/cert_authority.rs
@@ -30,7 +30,10 @@ async fn test_gen_server_config_creates_cert() {
     let ssl = Ssl::load_or_generate(dir.path()).unwrap();
     let authority: Authority = "example.com:443".parse().unwrap();
     let config = ssl.gen_server_config(&authority).await.unwrap();
-    assert!(!config.alpn_protocols.is_empty());
+    assert_eq!(
+        config.alpn_protocols,
+        vec![b"h2".to_vec(), b"http/1.1".to_vec()]
+    );
 }
 
 #[tokio::test]

--- a/proxyapi/tests/forward_proxy.rs
+++ b/proxyapi/tests/forward_proxy.rs
@@ -1,10 +1,10 @@
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use proxyapi::{Proxy, ProxyConfig, ProxyEvent, ProxyMode, DEFAULT_BODY_CAPTURE_LIMIT};
 use proxyapi_models::ProxiedRequest;
 use std::net::SocketAddr;
@@ -111,6 +111,67 @@ async fn forward_proxy_forwards_absolute_http_and_emits_request_complete() {
 }
 
 #[tokio::test]
+async fn forward_proxy_forwards_h2c_absolute_http_and_emits_http2_capture() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown) = start_upstream_server().await;
+    let (proxy_addr, shutdown_tx, handle, mut event_rx, _ca_dir) = start_forward_proxy().await;
+
+    let mut sender = connect_h2(proxy_addr).await;
+    let request = Request::builder()
+        .method(http::Method::GET)
+        .version(http::Version::HTTP_2)
+        .uri(format!("http://{upstream_addr}/h2c?via=proxy"))
+        .header("x-client-test", "h2c-absolute-roundtrip")
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    let response = sender.send_request(request).await.unwrap();
+
+    assert_eq!(response.version(), http::Version::HTTP_2);
+    assert_eq!(response.status(), http::StatusCode::OK);
+    assert_eq!(
+        response.headers()["x-upstream-path-query"],
+        "/h2c?via=proxy"
+    );
+    assert_eq!(
+        response.headers()["x-upstream-host"],
+        upstream_addr.to_string()
+    );
+    assert_eq!(response.headers()["x-upstream-version"], "HTTP/1.1");
+    assert_eq!(
+        response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .as_ref(),
+        b"forward response"
+    );
+
+    match recv_request_complete(&mut event_rx).await {
+        ProxyEvent::RequestComplete {
+            request, response, ..
+        } => {
+            assert_eq!(request.version(), http::Version::HTTP_2);
+            assert_eq!(request.uri().scheme_str(), Some("http"));
+            assert_eq!(
+                request.uri().authority().unwrap().as_str(),
+                upstream_addr.to_string()
+            );
+            assert_eq!(request.uri().path(), "/h2c");
+            assert_eq!(request.headers()["x-client-test"], "h2c-absolute-roundtrip");
+            assert_eq!(response.status(), http::StatusCode::OK);
+            assert_eq!(response.body().as_ref(), b"forward response");
+        }
+        other => panic!("expected RequestComplete event, got {other:?}"),
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = upstream_shutdown.send(());
+    assert!(handle.await.unwrap().is_ok());
+}
+
+#[tokio::test]
 async fn forward_proxy_connect_plain_http_reconstructs_uri_and_emits_request_complete() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let (upstream_addr, upstream_shutdown) = start_upstream_server().await;
@@ -173,6 +234,71 @@ async fn forward_proxy_connect_plain_http_reconstructs_uri_and_emits_request_com
             assert_eq!(request.headers()["x-client-test"], "connect-roundtrip");
             assert_eq!(response.status(), http::StatusCode::OK);
             assert_eq!(response.body().as_ref(), b"forward response");
+        }
+        other => panic!("expected RequestComplete event, got {other:?}"),
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = upstream_shutdown.send(());
+    assert!(handle.await.unwrap().is_ok());
+}
+
+#[tokio::test]
+async fn forward_proxy_h2_connect_tunnels_h2c_requests() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown) = start_upstream_server().await;
+    let (proxy_addr, shutdown_tx, handle, mut event_rx, _ca_dir) = start_forward_proxy().await;
+
+    let mut outer_sender = connect_h2(proxy_addr).await;
+    let connect = Request::builder()
+        .method(http::Method::CONNECT)
+        .version(http::Version::HTTP_2)
+        .uri(upstream_addr.to_string())
+        .body(Full::new(Bytes::new()))
+        .unwrap();
+    let connect_response = outer_sender.send_request(connect).await.unwrap();
+    assert_eq!(connect_response.status(), http::StatusCode::OK);
+
+    let upgraded = hyper::upgrade::on(connect_response).await.unwrap();
+    let mut inner_sender = connect_h2_io(upgraded).await;
+    let request = Request::builder()
+        .method(http::Method::POST)
+        .version(http::Version::HTTP_2)
+        .uri(format!("http://{upstream_addr}/h2-tunnel?via=connect"))
+        .header("x-client-test", "h2-connect-roundtrip")
+        .body(Full::new(Bytes::from_static(b"body through h2 connect")))
+        .unwrap();
+    let response = inner_sender.send_request(request).await.unwrap();
+
+    assert_eq!(response.version(), http::Version::HTTP_2);
+    assert_eq!(response.status(), http::StatusCode::OK);
+    assert_eq!(
+        response.headers()["x-upstream-path-query"],
+        "/h2-tunnel?via=connect"
+    );
+    assert_eq!(response.headers()["x-upstream-version"], "HTTP/1.1");
+    assert_eq!(
+        response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .as_ref(),
+        b"forward response"
+    );
+
+    match recv_request_complete(&mut event_rx).await {
+        ProxyEvent::RequestComplete {
+            request, response, ..
+        } => {
+            assert_eq!(request.version(), http::Version::HTTP_2);
+            assert_eq!(request.method(), http::Method::POST);
+            assert_eq!(request.uri().path(), "/h2-tunnel");
+            assert_eq!(request.uri().query(), Some("via=connect"));
+            assert_eq!(request.headers()["x-client-test"], "h2-connect-roundtrip");
+            assert_eq!(request.body().as_ref(), b"body through h2 connect");
+            assert_eq!(response.status(), http::StatusCode::OK);
         }
         other => panic!("expected RequestComplete event, got {other:?}"),
     }
@@ -641,6 +767,25 @@ async fn wait_for_tcp(addr: SocketAddr) -> Result<(), std::io::Error> {
     }
 }
 
+async fn connect_h2(addr: SocketAddr) -> hyper::client::conn::http2::SendRequest<Full<Bytes>> {
+    let stream = TcpStream::connect(addr).await.unwrap();
+    connect_h2_io(TokioIo::new(stream)).await
+}
+
+async fn connect_h2_io<I>(io: I) -> hyper::client::conn::http2::SendRequest<Full<Bytes>>
+where
+    I: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static,
+{
+    let (sender, connection) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+        .handshake(io)
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    sender
+}
+
 async fn write_connect(stream: &mut TcpStream, authority: SocketAddr) {
     stream
         .write_all(
@@ -775,6 +920,7 @@ async fn upstream_response(req: Request<Incoming>) -> Result<Response<Full<Bytes
         .status(http::StatusCode::OK)
         .header("x-upstream-path-query", path_query)
         .header("x-upstream-host", host)
+        .header("x-upstream-version", format!("{:?}", req.version()))
         .body(Full::new(Bytes::from_static(b"forward response")))
         .unwrap())
 }

--- a/proxyapi/tests/reverse_proxy.rs
+++ b/proxyapi/tests/reverse_proxy.rs
@@ -3,7 +3,7 @@ use http_body_util::{BodyExt, Full};
 use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
-use hyper_util::rt::TokioIo;
+use hyper_util::rt::{TokioExecutor, TokioIo};
 use proxyapi::{
     InterceptConfig, InterceptDecision, Proxy, ProxyConfig, ProxyEvent, ProxyMode,
     DEFAULT_BODY_CAPTURE_LIMIT,
@@ -123,6 +123,89 @@ async fn reverse_proxy_forwards_http_and_emits_request_complete() {
     let _ = shutdown_tx.send(());
     let _ = upstream_shutdown.send(());
 
+    assert!(handle.await.unwrap().is_ok());
+}
+
+#[tokio::test]
+async fn reverse_proxy_forwards_h2c_post_and_emits_http2_capture() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown) = start_echo_request_body_server().await;
+    let proxy_addr = reserve_loopback_addr().await;
+    let ca_dir = tempfile::tempdir().unwrap();
+
+    let (event_tx, mut event_rx) = mpsc::channel::<ProxyEvent>(100);
+    let config = ProxyConfig {
+        addr: proxy_addr,
+        mode: ProxyMode::Reverse {
+            target: format!("http://{upstream_addr}").parse().unwrap(),
+        },
+        event_tx,
+        ca_dir: ca_dir.path().to_path_buf(),
+        intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
+        #[cfg(feature = "scripting")]
+        script_path: None,
+        replay_rx: None,
+    };
+
+    let proxy = Proxy::new(config);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let handle = tokio::spawn(async move {
+        proxy
+            .start(async {
+                shutdown_rx.await.ok();
+            })
+            .await
+    });
+
+    wait_for_tcp(proxy_addr).await;
+
+    let mut sender = connect_h2(proxy_addr).await;
+    let request = Request::builder()
+        .method(http::Method::POST)
+        .version(http::Version::HTTP_2)
+        .uri(format!("http://{proxy_addr}/echo?via=h2c"))
+        .header("x-client-test", "reverse-h2c")
+        .body(Full::new(Bytes::from_static(b"reverse h2 body")))
+        .unwrap();
+    let response = sender.send_request(request).await.unwrap();
+
+    assert_eq!(response.version(), http::Version::HTTP_2);
+    assert_eq!(response.status(), http::StatusCode::CREATED);
+    assert_eq!(response.headers()["x-upstream-version"], "HTTP/1.1");
+    assert_eq!(
+        response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .as_ref(),
+        b"reverse h2 body"
+    );
+
+    let event = tokio::time::timeout(EVENT_TIMEOUT, event_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    match event {
+        ProxyEvent::RequestComplete {
+            request, response, ..
+        } => {
+            assert_eq!(request.version(), http::Version::HTTP_2);
+            assert_eq!(request.method(), http::Method::POST);
+            assert_eq!(request.uri().path(), "/echo");
+            assert_eq!(request.uri().query(), Some("via=h2c"));
+            assert_eq!(request.headers()["x-client-test"], "reverse-h2c");
+            assert_eq!(request.body().as_ref(), b"reverse h2 body");
+            assert_eq!(response.status(), http::StatusCode::CREATED);
+            assert_eq!(response.body().as_ref(), b"reverse h2 body");
+        }
+        other => panic!("expected RequestComplete event, got {other:?}"),
+    }
+
+    let _ = shutdown_tx.send(());
+    let _ = upstream_shutdown.send(());
     assert!(handle.await.unwrap().is_ok());
 }
 
@@ -541,6 +624,18 @@ async fn wait_for_tcp(addr: SocketAddr) {
     }
 }
 
+async fn connect_h2(addr: SocketAddr) -> hyper::client::conn::http2::SendRequest<Full<Bytes>> {
+    let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (sender, connection) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+        .handshake(TokioIo::new(stream))
+        .await
+        .unwrap();
+    tokio::spawn(async move {
+        let _ = connection.await;
+    });
+    sender
+}
+
 async fn start_upstream_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -611,9 +706,12 @@ async fn echo_request_body_response(
 ) -> Result<Response<Full<Bytes>>, hyper::Error> {
     let script_header = req.headers().get("x-script").cloned();
     let intercept_header = req.headers().get("x-intercept").cloned();
+    let upstream_version = format!("{:?}", req.version());
     let body = req.into_body().collect().await?.to_bytes();
 
-    let mut builder = Response::builder().status(http::StatusCode::CREATED);
+    let mut builder = Response::builder()
+        .status(http::StatusCode::CREATED)
+        .header("x-upstream-version", upstream_version);
     if let Some(value) = script_header {
         builder = builder.header("x-seen-script", value);
     }


### PR DESCRIPTION
Adds HTTP/2 support for proxy client connections, with coverage for forward and reverse proxy flows.