### PR TITLE
Upstream tls trust policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 
+- Add upstream HTTPS trust policy configuration for default roots, extra CA files, CA-only trust, and insecure debugging.
 - Accept HTTP/2 client connections in forward and reverse proxy modes while preserving HTTP/1.1 upstream forwarding invariants.
 - Emit visible flow events for Lua short-circuits, intercept drops, replay failures, and upstream proxy errors.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,7 +2056,6 @@ dependencies = [
  "proxyapi_models",
  "reqwest",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "tempfile",
@@ -2457,15 +2456,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "proxyapi_models",
  "reqwest",
  "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "tempfile",
@@ -2065,6 +2066,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "tracing",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2455,6 +2457,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ proxelar -m reverse --target http://localhost:3000   # reverse proxy
 proxelar -b 0.0.0.0 -p 9090                         # custom bind/port
 proxelar --script examples/scripts/block_domain.lua  # with a Lua script
 proxelar --body-capture-limit 1048576                # cap captured/editable body bytes
+proxelar --upstream-trust default+ca:/path/ca.pem    # trust an extra upstream CA
 ```
 
 <details>
@@ -126,8 +127,11 @@ proxelar --body-capture-limit 1048576                # cap captured/editable bod
 | `--ca-dir` | CA certificate directory | `~/.proxelar` |
 | `-s, --script` | Lua script for request/response hooks | — |
 | `--body-capture-limit` | Maximum body bytes buffered for capture/editing; use `free`, `unlimited`, or `none` for unlimited | `free` |
+| `--upstream-trust` | Upstream TLS trust policy: `default`, `default+ca:/path/ca.pem`, `ca-only:/path/ca.pem`, or `insecure` | `default` |
 
 </details>
+
+`--upstream-trust insecure` disables upstream certificate and hostname verification. Use it only for controlled debugging; it makes upstream HTTPS traffic vulnerable to MITM.
 
 <details>
 <summary><strong>TUI key bindings</strong></summary>

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -17,6 +17,9 @@ proxelar [OPTIONS]
 | `--gui-port` | | `8081` | Web GUI port (only used with `-i gui`) |
 | `--ca-dir` | | `~/.proxelar` | Directory for CA certificate and key files |
 | `--body-capture-limit` | | `free` | Maximum body bytes buffered for capture/editing; use `free`, `unlimited`, or `none` for unlimited |
+| `--upstream-trust` | | `default` | Upstream TLS trust policy: `default`, `default+ca:/path/ca.pem`, `ca-only:/path/ca.pem`, or `insecure` |
+
+`--upstream-trust insecure` disables upstream certificate and hostname verification. Use it only for controlled debugging; it makes upstream HTTPS traffic vulnerable to MITM.
 
 ## Environment variables
 
@@ -44,4 +47,10 @@ proxelar --script log_traffic.lua
 
 # Capture only the first 1 MiB of large bodies while streaming traffic through
 proxelar --body-capture-limit 1048576
+
+# Trust a private upstream CA in addition to the default Mozilla roots
+proxelar --upstream-trust default+ca:/path/to/ca.pem
+
+# Trust only a private upstream CA
+proxelar --upstream-trust ca-only:/path/to/ca.pem
 ```

--- a/docs/src/proxy-modes/forward.md
+++ b/docs/src/proxy-modes/forward.md
@@ -38,4 +38,9 @@ proxelar --script block_ads.lua
 # Test with curl
 curl -x http://127.0.0.1:8080 http://httpbin.org/get
 curl -x http://127.0.0.1:8080 https://httpbin.org/get
+
+# Trust an extra private CA when Proxelar connects to upstream HTTPS servers
+proxelar --upstream-trust default+ca:/path/to/ca.pem
 ```
+
+For upstream HTTPS, Proxelar uses bundled Mozilla/WebPKI roots by default. `--upstream-trust ca-only:/path/to/ca.pem` trusts only a supplied CA file, and `--upstream-trust insecure` disables upstream certificate and hostname verification for controlled debugging. `insecure` makes upstream HTTPS traffic vulnerable to MITM.

--- a/docs/src/proxy-modes/reverse.md
+++ b/docs/src/proxy-modes/reverse.md
@@ -34,7 +34,12 @@ proxelar -m reverse --target http://localhost:3000 --script auth_dev.lua
 
 # With web GUI
 proxelar -m reverse --target http://localhost:3000 -i gui
+
+# HTTPS upstream with a private CA
+proxelar -m reverse --target https://localhost:3000 --upstream-trust default+ca:/path/to/ca.pem
 ```
+
+For upstream HTTPS, Proxelar uses bundled Mozilla/WebPKI roots by default. Use `--upstream-trust default+ca:/path/to/ca.pem` to add a private CA, `--upstream-trust ca-only:/path/to/ca.pem` to trust only that CA, or `--upstream-trust insecure` for temporary debugging without certificate or hostname verification. `insecure` makes upstream HTTPS traffic vulnerable to MITM.
 
 ## Common use cases with scripting
 

--- a/proxelar-cli/src/cli.rs
+++ b/proxelar-cli/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, ValueEnum};
+use proxyapi::UpstreamTlsConfig;
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -49,6 +50,14 @@ pub struct Args {
         default_value = "free"
     )]
     pub body_capture_limit: BodyCaptureLimit,
+
+    /// Upstream HTTPS trust policy: default, default+ca:/path/to/ca.pem, ca-only:/path/to/ca.pem, or insecure
+    #[arg(
+        long = "upstream-trust",
+        value_name = "POLICY",
+        default_value = "default"
+    )]
+    pub upstream_trust: UpstreamTlsConfig,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -108,6 +117,7 @@ mod tests {
             args.body_capture_limit.into_option(),
             proxyapi::DEFAULT_BODY_CAPTURE_LIMIT
         );
+        assert_eq!(args.upstream_trust, UpstreamTlsConfig::Default);
     }
 
     #[test]
@@ -135,5 +145,56 @@ mod tests {
         let args = Args::parse_from(["proxelar", "--body-capture-limit", "free"]);
 
         assert_eq!(args.body_capture_limit, BodyCaptureLimit::Unlimited);
+    }
+
+    #[test]
+    fn test_upstream_trust_default_arg() {
+        let args = Args::parse_from(["proxelar", "--upstream-trust", "default"]);
+
+        assert_eq!(args.upstream_trust, UpstreamTlsConfig::Default);
+    }
+
+    #[test]
+    fn test_upstream_trust_default_with_ca_arg() {
+        let args = Args::parse_from(["proxelar", "--upstream-trust", "default+ca:/tmp/ca.pem"]);
+
+        assert_eq!(
+            args.upstream_trust,
+            UpstreamTlsConfig::DefaultWithCaFile(PathBuf::from("/tmp/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn test_upstream_trust_ca_only_arg() {
+        let args = Args::parse_from(["proxelar", "--upstream-trust", "ca-only:/tmp/ca.pem"]);
+
+        assert_eq!(
+            args.upstream_trust,
+            UpstreamTlsConfig::CaFileOnly(PathBuf::from("/tmp/ca.pem"))
+        );
+    }
+
+    #[test]
+    fn test_upstream_trust_insecure_arg() {
+        let args = Args::parse_from(["proxelar", "--upstream-trust", "insecure"]);
+
+        assert_eq!(args.upstream_trust, UpstreamTlsConfig::Insecure);
+    }
+
+    #[test]
+    fn test_upstream_trust_rejects_malformed_values() {
+        for value in [
+            "default+ca:",
+            "default+ca:   ",
+            "ca-only:",
+            "ca-only:   ",
+            "default+ca",
+            "ca-only",
+            "unknown",
+            "",
+        ] {
+            let result = Args::try_parse_from(["proxelar", "--upstream-trust", value]);
+            assert!(result.is_err(), "{value:?} should be rejected");
+        }
     }
 }

--- a/proxelar-cli/src/main.rs
+++ b/proxelar-cli/src/main.rs
@@ -54,6 +54,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         mode: proxy_mode,
         event_tx,
         ca_dir,
+        upstream_tls: args.upstream_trust,
         intercept: Some(Arc::clone(&intercept)),
         body_capture_limit: args.body_capture_limit.into_option(),
         #[cfg(feature = "scripting")]

--- a/proxyapi/Cargo.toml
+++ b/proxyapi/Cargo.toml
@@ -27,7 +27,6 @@ bytes = "1.9"
 tokio-rustls = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 rustls-pki-types = "1.14"
-rustls-pemfile = "2"
 hyper-rustls = { version = "0.27", features = ["http1", "logging", "tls12", "ring", "webpki-tokio"] }
 webpki-roots = "1.0"
 openssl = { version = "0.10.79", features = ["vendored"] }

--- a/proxyapi/Cargo.toml
+++ b/proxyapi/Cargo.toml
@@ -27,7 +27,9 @@ bytes = "1.9"
 tokio-rustls = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 rustls-pki-types = "1.14"
+rustls-pemfile = "2"
 hyper-rustls = { version = "0.27", features = ["http1", "logging", "tls12", "ring", "webpki-tokio"] }
+webpki-roots = "1.0"
 openssl = { version = "0.10.79", features = ["vendored"] }
 moka = { version = "0.12", features = ["future"] }
 tokio = { version = "1.52", features = ["rt", "net", "io-util", "macros", "sync", "time"] }

--- a/proxyapi/src/lib.rs
+++ b/proxyapi/src/lib.rs
@@ -24,7 +24,7 @@ pub use error::Error;
 pub use event::ProxyEvent;
 pub use handler::{CapturingHandler, DEFAULT_BODY_CAPTURE_LIMIT};
 pub use intercept::{InterceptConfig, InterceptDecision};
-pub use proxy::{Proxy, ProxyConfig, ProxyMode};
+pub use proxy::{Proxy, ProxyConfig, ProxyMode, UpstreamTlsConfig};
 
 /// Returned by [`HttpHandler::handle_request`] to either forward or short-circuit.
 pub enum RequestOrResponse {

--- a/proxyapi/src/proxy/mod.rs
+++ b/proxyapi/src/proxy/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod forward;
 pub(crate) mod reverse;
+mod tls;
 
 use std::{error::Error as StdError, future::Future, net::SocketAddr, path::PathBuf, sync::Arc};
 
@@ -26,6 +27,8 @@ use crate::handler::CapturingHandler;
 use crate::intercept::InterceptConfig;
 #[cfg(feature = "scripting")]
 use crate::scripting::ScriptEngine;
+
+pub use tls::UpstreamTlsConfig;
 
 /// Shared HTTP(S) client type used by both forward and reverse proxy.
 pub(crate) type Client =
@@ -153,6 +156,8 @@ pub struct ProxyConfig {
     pub event_tx: mpsc::Sender<ProxyEvent>,
     /// Directory for CA certificate and key files.
     pub ca_dir: PathBuf,
+    /// Upstream HTTPS server trust policy.
+    pub upstream_tls: UpstreamTlsConfig,
     /// Optional intercept controller for interactive request/response editing.
     pub intercept: Option<Arc<InterceptConfig>>,
     /// Maximum body bytes buffered for capture/editing before streaming passthrough.
@@ -210,8 +215,15 @@ impl Proxy {
         let ca =
             Arc::new(tokio::task::spawn_blocking(move || Ssl::load_or_generate(&ca_dir)).await??);
 
+        if self.config.upstream_tls.is_insecure() {
+            tracing::warn!(
+                "Upstream TLS certificate verification is disabled; traffic is vulnerable to upstream MITM"
+            );
+        }
+
+        let tls_config = tls::build_client_config(&self.config.upstream_tls)?;
         let https = hyper_rustls::HttpsConnectorBuilder::new()
-            .with_webpki_roots()
+            .with_tls_config(tls_config)
             .https_or_http()
             .enable_http1()
             .build();
@@ -324,6 +336,7 @@ mod tests {
             },
             event_tx,
             ca_dir: PathBuf::from("."),
+            upstream_tls: UpstreamTlsConfig::Default,
             intercept: None,
             body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
             #[cfg(feature = "scripting")]

--- a/proxyapi/src/proxy/tls.rs
+++ b/proxyapi/src/proxy/tls.rs
@@ -1,6 +1,4 @@
 use std::{
-    fs::File,
-    io::BufReader,
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
@@ -13,6 +11,7 @@ use rustls::{
     ClientConfig, ConfigBuilder, DigitallySignedStruct, RootCertStore, SignatureScheme,
     WantsVerifier,
 };
+use rustls_pki_types::pem::{self, PemObject};
 
 use crate::error::Error;
 
@@ -113,9 +112,10 @@ fn append_ca_file_roots(roots: &mut RootCertStore, path: &Path) -> Result<(), Er
 }
 
 fn load_ca_file_roots(path: &Path) -> Result<RootCertStore, Error> {
-    let file = File::open(path)?;
-    let mut reader = BufReader::new(file);
-    let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?;
+    let certs = CertificateDer::pem_file_iter(path)
+        .map_err(map_pem_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(map_pem_error)?;
 
     let mut roots = RootCertStore::empty();
     let (valid_count, invalid_count) = roots.add_parsable_certificates(certs);
@@ -133,6 +133,13 @@ fn load_ca_file_roots(path: &Path) -> Result<RootCertStore, Error> {
     }
 
     Ok(roots)
+}
+
+fn map_pem_error(err: pem::Error) -> Error {
+    match err {
+        pem::Error::Io(err) => Error::Io(err),
+        err => Error::Other(format!("failed to parse PEM certificate: {err}")),
+    }
 }
 
 /// Skips certificate chain and hostname checks while retaining Rustls handshake signature checks.

--- a/proxyapi/src/proxy/tls.rs
+++ b/proxyapi/src/proxy/tls.rs
@@ -1,0 +1,245 @@
+use std::{
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
+
+use rustls::{
+    client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, ServerName, UnixTime},
+    ClientConfig, ConfigBuilder, DigitallySignedStruct, RootCertStore, SignatureScheme,
+    WantsVerifier,
+};
+
+use crate::error::Error;
+
+/// Upstream server TLS trust policy.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum UpstreamTlsConfig {
+    /// Trust the bundled Mozilla/WebPKI roots.
+    #[default]
+    Default,
+    /// Trust the bundled Mozilla/WebPKI roots plus the supplied PEM CA file.
+    DefaultWithCaFile(PathBuf),
+    /// Trust only the supplied PEM CA file.
+    CaFileOnly(PathBuf),
+    /// Disable upstream certificate and hostname validation.
+    Insecure,
+}
+
+impl FromStr for UpstreamTlsConfig {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim();
+        if value == "default" {
+            return Ok(Self::Default);
+        }
+        if value == "insecure" {
+            return Ok(Self::Insecure);
+        }
+        if let Some(path) = value.strip_prefix("default+ca:") {
+            return path_to_policy(path, Self::DefaultWithCaFile);
+        }
+        if let Some(path) = value.strip_prefix("ca-only:") {
+            return path_to_policy(path, Self::CaFileOnly);
+        }
+
+        Err("expected `default`, `default+ca:/path/to/ca.pem`, `ca-only:/path/to/ca.pem`, or `insecure`".to_owned())
+    }
+}
+
+impl UpstreamTlsConfig {
+    pub(crate) fn is_insecure(&self) -> bool {
+        matches!(self, Self::Insecure)
+    }
+}
+
+fn path_to_policy(
+    path: &str,
+    make_policy: impl FnOnce(PathBuf) -> UpstreamTlsConfig,
+) -> Result<UpstreamTlsConfig, String> {
+    let path = path.trim();
+    if path.is_empty() {
+        return Err("CA file path must not be empty".to_owned());
+    }
+    Ok(make_policy(PathBuf::from(path)))
+}
+
+pub(super) fn build_client_config(config: &UpstreamTlsConfig) -> Result<ClientConfig, Error> {
+    match config {
+        UpstreamTlsConfig::Default => Ok(client_config_builder()?
+            .with_root_certificates(default_root_store())
+            .with_no_client_auth()),
+        UpstreamTlsConfig::DefaultWithCaFile(path) => {
+            let mut roots = default_root_store();
+            append_ca_file_roots(&mut roots, path)?;
+            Ok(client_config_builder()?
+                .with_root_certificates(roots)
+                .with_no_client_auth())
+        }
+        UpstreamTlsConfig::CaFileOnly(path) => Ok(client_config_builder()?
+            .with_root_certificates(load_ca_file_roots(path)?)
+            .with_no_client_auth()),
+        UpstreamTlsConfig::Insecure => {
+            let provider = Arc::new(rustls::crypto::ring::default_provider());
+            Ok(
+                rustls::ClientConfig::builder_with_provider(Arc::clone(&provider))
+                    .with_safe_default_protocol_versions()?
+                    .dangerous()
+                    .with_custom_certificate_verifier(InsecureServerCertVerifier::new(provider))
+                    .with_no_client_auth(),
+            )
+        }
+    }
+}
+
+fn client_config_builder() -> Result<ConfigBuilder<ClientConfig, WantsVerifier>, rustls::Error> {
+    rustls::ClientConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+        .with_safe_default_protocol_versions()
+}
+
+fn default_root_store() -> RootCertStore {
+    RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned())
+}
+
+fn append_ca_file_roots(roots: &mut RootCertStore, path: &Path) -> Result<(), Error> {
+    let ca_roots = load_ca_file_roots(path)?;
+    roots.roots.extend(ca_roots.roots);
+    Ok(())
+}
+
+fn load_ca_file_roots(path: &Path) -> Result<RootCertStore, Error> {
+    let file = File::open(path)?;
+    let mut reader = BufReader::new(file);
+    let certs = rustls_pemfile::certs(&mut reader).collect::<Result<Vec<_>, _>>()?;
+
+    let mut roots = RootCertStore::empty();
+    let (valid_count, invalid_count) = roots.add_parsable_certificates(certs);
+    if valid_count == 0 {
+        return Err(Error::Other(format!(
+            "no usable CA certificates found in {}",
+            path.display()
+        )));
+    }
+    if invalid_count > 0 {
+        tracing::warn!(
+            "Ignored {invalid_count} invalid CA certificate(s) while loading {}",
+            path.display()
+        );
+    }
+
+    Ok(roots)
+}
+
+/// Skips certificate chain and hostname checks while retaining Rustls handshake signature checks.
+#[derive(Debug)]
+struct InsecureServerCertVerifier(Arc<CryptoProvider>);
+
+impl InsecureServerCertVerifier {
+    fn new(provider: Arc<CryptoProvider>) -> Arc<Self> {
+        Arc::new(Self(provider))
+    }
+}
+
+impl ServerCertVerifier for InsecureServerCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.0.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ca::Ssl;
+
+    #[test]
+    fn load_ca_file_roots_accepts_valid_pem() {
+        let ca_dir = tempfile::tempdir().unwrap();
+        let ssl = Ssl::load_or_generate(ca_dir.path()).unwrap();
+        let ca_file = ca_dir.path().join("upstream-ca.pem");
+        std::fs::write(&ca_file, ssl.ca_cert_pem()).unwrap();
+
+        let roots = load_ca_file_roots(&ca_file).unwrap();
+
+        assert_eq!(roots.len(), 1);
+    }
+
+    #[test]
+    fn load_ca_file_roots_rejects_empty_pem() {
+        let ca_dir = tempfile::tempdir().unwrap();
+        let ca_file = ca_dir.path().join("empty.pem");
+        std::fs::write(&ca_file, "").unwrap();
+
+        let err = load_ca_file_roots(&ca_file).unwrap_err();
+
+        assert!(err.to_string().contains("no usable CA certificates"));
+    }
+
+    #[test]
+    fn load_ca_file_roots_rejects_invalid_pem() {
+        let ca_dir = tempfile::tempdir().unwrap();
+        let ca_file = ca_dir.path().join("invalid.pem");
+        std::fs::write(
+            &ca_file,
+            "-----BEGIN CERTIFICATE-----\naW52YWxpZA==\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+
+        let err = load_ca_file_roots(&ca_file).unwrap_err();
+
+        assert!(err.to_string().contains("no usable CA certificates"));
+    }
+
+    #[test]
+    fn load_ca_file_roots_rejects_missing_file() {
+        let ca_dir = tempfile::tempdir().unwrap();
+        let ca_file = ca_dir.path().join("missing.pem");
+
+        let err = load_ca_file_roots(&ca_file).unwrap_err();
+
+        assert!(matches!(err, Error::Io(_)));
+    }
+}

--- a/proxyapi/tests/forward_proxy.rs
+++ b/proxyapi/tests/forward_proxy.rs
@@ -5,7 +5,9 @@ use hyper::body::Incoming;
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo};
-use proxyapi::{Proxy, ProxyConfig, ProxyEvent, ProxyMode, DEFAULT_BODY_CAPTURE_LIMIT};
+use proxyapi::{
+    Proxy, ProxyConfig, ProxyEvent, ProxyMode, UpstreamTlsConfig, DEFAULT_BODY_CAPTURE_LIMIT,
+};
 use proxyapi_models::ProxiedRequest;
 use std::net::SocketAddr;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -30,6 +32,7 @@ async fn test_forward_proxy_starts_and_shuts_down() {
         mode: ProxyMode::Forward,
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
@@ -686,6 +689,7 @@ async fn start_forward_proxy() -> (
         mode: ProxyMode::Forward,
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
@@ -725,6 +729,7 @@ async fn start_forward_proxy_with_replay() -> (
         mode: ProxyMode::Forward,
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]

--- a/proxyapi/tests/reverse_proxy.rs
+++ b/proxyapi/tests/reverse_proxy.rs
@@ -6,7 +6,7 @@ use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use proxyapi::{
     InterceptConfig, InterceptDecision, Proxy, ProxyConfig, ProxyEvent, ProxyMode,
-    DEFAULT_BODY_CAPTURE_LIMIT,
+    UpstreamTlsConfig, DEFAULT_BODY_CAPTURE_LIMIT,
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -30,6 +30,7 @@ async fn test_reverse_proxy_starts_and_shuts_down() {
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
@@ -71,6 +72,7 @@ async fn reverse_proxy_forwards_http_and_emits_request_complete() {
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
@@ -141,6 +143,7 @@ async fn reverse_proxy_forwards_h2c_post_and_emits_http2_capture() {
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
@@ -224,6 +227,7 @@ async fn reverse_proxy_returns_502_when_target_is_unreachable() {
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
@@ -271,6 +275,72 @@ async fn reverse_proxy_returns_502_when_target_is_unreachable() {
 }
 
 #[tokio::test]
+async fn reverse_proxy_default_upstream_tls_rejects_private_ca() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown, _ca_pem) = start_private_ca_https_upstream().await;
+
+    let (status, body) =
+        request_private_ca_https_upstream(upstream_addr, UpstreamTlsConfig::Default).await;
+
+    assert_eq!(status, reqwest::StatusCode::BAD_GATEWAY);
+    assert_eq!(body, "Bad Gateway");
+
+    let _ = upstream_shutdown.send(());
+}
+
+#[tokio::test]
+async fn reverse_proxy_default_with_ca_file_trusts_private_ca() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown, ca_pem) = start_private_ca_https_upstream().await;
+    let ca_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(ca_file.path(), ca_pem).unwrap();
+
+    let (status, body) = request_private_ca_https_upstream(
+        upstream_addr,
+        UpstreamTlsConfig::DefaultWithCaFile(ca_file.path().to_path_buf()),
+    )
+    .await;
+
+    assert_eq!(status, reqwest::StatusCode::CREATED);
+    assert_eq!(body, "upstream response");
+
+    let _ = upstream_shutdown.send(());
+}
+
+#[tokio::test]
+async fn reverse_proxy_ca_file_only_trusts_private_ca() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown, ca_pem) = start_private_ca_https_upstream().await;
+    let ca_file = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(ca_file.path(), ca_pem).unwrap();
+
+    let (status, body) = request_private_ca_https_upstream(
+        upstream_addr,
+        UpstreamTlsConfig::CaFileOnly(ca_file.path().to_path_buf()),
+    )
+    .await;
+
+    assert_eq!(status, reqwest::StatusCode::CREATED);
+    assert_eq!(body, "upstream response");
+
+    let _ = upstream_shutdown.send(());
+}
+
+#[tokio::test]
+async fn reverse_proxy_insecure_upstream_tls_accepts_private_ca() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let (upstream_addr, upstream_shutdown, _ca_pem) = start_private_ca_https_upstream().await;
+
+    let (status, body) =
+        request_private_ca_https_upstream(upstream_addr, UpstreamTlsConfig::Insecure).await;
+
+    assert_eq!(status, reqwest::StatusCode::CREATED);
+    assert_eq!(body, "upstream response");
+
+    let _ = upstream_shutdown.send(());
+}
+
+#[tokio::test]
 async fn reverse_proxy_intercepts_oversized_request_before_streaming_original() {
     let _ = rustls::crypto::ring::default_provider().install_default();
     let (upstream_addr, upstream_shutdown) = start_echo_request_body_server().await;
@@ -287,6 +357,7 @@ async fn reverse_proxy_intercepts_oversized_request_before_streaming_original() 
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: Some(Arc::clone(&intercept)),
         body_capture_limit: Some(4),
         #[cfg(feature = "scripting")]
@@ -371,6 +442,7 @@ async fn reverse_proxy_intercept_drop_emits_request_complete() {
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: Some(Arc::clone(&intercept)),
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
@@ -486,6 +558,7 @@ async fn reverse_proxy_runs_scripts_for_oversized_request_and_response() {
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: Some(4),
         script_path: Some(script.path().to_path_buf()),
@@ -554,6 +627,7 @@ async fn reverse_proxy_lua_short_circuit_emits_request_complete() {
         },
         event_tx,
         ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls: UpstreamTlsConfig::Default,
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         script_path: Some(script.path().to_path_buf()),
@@ -636,6 +710,54 @@ async fn connect_h2(addr: SocketAddr) -> hyper::client::conn::http2::SendRequest
     sender
 }
 
+async fn request_private_ca_https_upstream(
+    upstream_addr: SocketAddr,
+    upstream_tls: UpstreamTlsConfig,
+) -> (reqwest::StatusCode, String) {
+    let proxy_addr = reserve_loopback_addr().await;
+    let ca_dir = tempfile::tempdir().unwrap();
+    let (event_tx, _event_rx) = mpsc::channel::<ProxyEvent>(100);
+    let config = ProxyConfig {
+        addr: proxy_addr,
+        mode: ProxyMode::Reverse {
+            target: format!("https://{upstream_addr}").parse().unwrap(),
+        },
+        event_tx,
+        ca_dir: ca_dir.path().to_path_buf(),
+        upstream_tls,
+        intercept: None,
+        body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
+        #[cfg(feature = "scripting")]
+        script_path: None,
+        replay_rx: None,
+    };
+
+    let proxy = Proxy::new(config);
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    let handle = tokio::spawn(async move {
+        proxy
+            .start(async {
+                shutdown_rx.await.ok();
+            })
+            .await
+    });
+
+    wait_for_tcp(proxy_addr).await;
+
+    let response = reqwest::Client::new()
+        .get(format!("http://{proxy_addr}/hello"))
+        .send()
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = response.text().await.unwrap();
+
+    let _ = shutdown_tx.send(());
+    assert!(handle.await.unwrap().is_ok());
+
+    (status, body)
+}
+
 async fn start_upstream_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -662,6 +784,163 @@ async fn start_upstream_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()
     });
 
     (addr, shutdown_tx)
+}
+
+async fn start_private_ca_https_upstream() -> (SocketAddr, tokio::sync::oneshot::Sender<()>, Vec<u8>)
+{
+    use openssl::{
+        asn1::{Asn1Integer, Asn1Time},
+        bn::BigNum,
+        hash::MessageDigest,
+        pkey::{PKey, Private},
+        rsa::Rsa,
+        x509::{
+            extension::{BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName},
+            X509Builder, X509NameBuilder, X509,
+        },
+    };
+    use rustls_pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs1KeyDer};
+    use tokio_rustls::TlsAcceptor;
+
+    fn random_serial_number() -> Asn1Integer {
+        let mut serial = [0; 16];
+        openssl::rand::rand_bytes(&mut serial).unwrap();
+        Asn1Integer::from_bn(&BigNum::from_slice(&serial).unwrap()).unwrap()
+    }
+
+    fn set_validity(builder: &mut openssl::x509::X509Builder) {
+        let not_before = std::time::SystemTime::now()
+            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+            - 60;
+        builder
+            .set_not_before(Asn1Time::from_unix(not_before).unwrap().as_ref())
+            .unwrap();
+        builder
+            .set_not_after(Asn1Time::from_unix(not_before + 86_400).unwrap().as_ref())
+            .unwrap();
+    }
+
+    fn generate_ca() -> (PKey<Private>, X509) {
+        let ca_key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        let mut name_builder = X509NameBuilder::new().unwrap();
+        name_builder
+            .append_entry_by_text("CN", "Proxelar Upstream Test CA")
+            .unwrap();
+        let name = name_builder.build();
+
+        let mut builder = X509Builder::new().unwrap();
+        builder.set_version(2).unwrap();
+        builder
+            .set_serial_number(random_serial_number().as_ref())
+            .unwrap();
+        builder.set_subject_name(&name).unwrap();
+        builder.set_issuer_name(&name).unwrap();
+        builder.set_pubkey(&ca_key).unwrap();
+        set_validity(&mut builder);
+        builder
+            .append_extension(BasicConstraints::new().critical().ca().build().unwrap())
+            .unwrap();
+        builder
+            .append_extension(
+                KeyUsage::new()
+                    .critical()
+                    .key_cert_sign()
+                    .crl_sign()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        builder.sign(&ca_key, MessageDigest::sha256()).unwrap();
+        (ca_key, builder.build())
+    }
+
+    fn generate_server_cert(ca_key: &PKey<Private>, ca_cert: &X509) -> (PKey<Private>, X509) {
+        let server_key = PKey::from_rsa(Rsa::generate(2048).unwrap()).unwrap();
+        let mut name_builder = X509NameBuilder::new().unwrap();
+        name_builder
+            .append_entry_by_text("CN", "127.0.0.1")
+            .unwrap();
+        let name = name_builder.build();
+
+        let mut builder = X509Builder::new().unwrap();
+        builder.set_version(2).unwrap();
+        builder
+            .set_serial_number(random_serial_number().as_ref())
+            .unwrap();
+        builder.set_subject_name(&name).unwrap();
+        builder.set_issuer_name(ca_cert.subject_name()).unwrap();
+        builder.set_pubkey(&server_key).unwrap();
+        set_validity(&mut builder);
+        builder
+            .append_extension(BasicConstraints::new().critical().build().unwrap())
+            .unwrap();
+        builder
+            .append_extension(
+                KeyUsage::new()
+                    .critical()
+                    .digital_signature()
+                    .key_encipherment()
+                    .build()
+                    .unwrap(),
+            )
+            .unwrap();
+        builder
+            .append_extension(ExtendedKeyUsage::new().server_auth().build().unwrap())
+            .unwrap();
+        let subject_alt_name = SubjectAlternativeName::new()
+            .ip("127.0.0.1")
+            .build(&builder.x509v3_context(Some(ca_cert), None))
+            .unwrap();
+        builder.append_extension(subject_alt_name).unwrap();
+        builder.sign(ca_key, MessageDigest::sha256()).unwrap();
+        (server_key, builder.build())
+    }
+
+    let (ca_key, ca_cert) = generate_ca();
+    let (server_key, server_cert) = generate_server_cert(&ca_key, &ca_cert);
+    let ca_pem = ca_cert.to_pem().unwrap();
+    let certs = vec![CertificateDer::from(server_cert.to_der().unwrap())];
+    let private_key = PrivateKeyDer::Pkcs1(PrivatePkcs1KeyDer::from(
+        server_key.rsa().unwrap().private_key_to_der().unwrap(),
+    ));
+
+    let server_config = tokio_rustls::rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, private_key)
+        .unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                result = listener.accept() => {
+                    let Ok((stream, _)) = result else {
+                        break;
+                    };
+                    let acceptor = acceptor.clone();
+                    tokio::spawn(async move {
+                        let Ok(stream) = acceptor.accept(stream).await else {
+                            return;
+                        };
+                        let io = TokioIo::new(stream);
+                        let service = service_fn(upstream_response);
+                        let _ = hyper::server::conn::http1::Builder::new()
+                            .serve_connection(io, service)
+                            .await;
+                    });
+                }
+                _ = &mut shutdown_rx => break,
+            }
+        }
+    });
+
+    (addr, shutdown_tx, ca_pem)
 }
 
 async fn start_echo_request_body_server() -> (SocketAddr, tokio::sync::oneshot::Sender<()>) {


### PR DESCRIPTION
## Summary
- Add `--upstream-trust` for upstream HTTPS trust policy configuration.
- Support default bundled roots, an extra CA file, CA-only trust, and insecure debugging mode.
- Fixes #137.

## Changelog
- [x] I have added an entry to `CHANGELOG.md` under `[Unreleased]`, or this PR does not need one

## Tests
- [x] I have added or updated tests for user-visible behavior changes, or this PR does not need tests
- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo test --workspace --no-default-features`
- `cargo build --workspace`
- `cargo build --workspace --no-default-features`
- `cargo clippy --workspace -- -D warnings`
- `cargo deny check`
