### PR TITLE
feat(scripting): allow loading native Lua C modules

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Test without default features
         run: cargo test --workspace --locked --no-default-features
       - name: Test proxyapi scripting explicitly
-        run: cargo test -p proxyapi --locked --features scripting -- scripting
+        run: cargo test -p proxyapi --locked --features scripting,vendored-lua -- scripting
 
   coverage:
     name: Coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,65 @@ jobs:
           name: proxelar-${{ matrix.target }}
           path: proxelar-${{ github.ref_name }}-${{ matrix.target }}.*
 
+  # Windows build that links a shared lua54.dll instead of vendoring Lua, so
+  # scripts run with --allow-c-modules can `require` native modules (e.g.
+  # lua-protobuf). The DLL is bundled alongside the executable.
+  build-windows-cmodules:
+    name: Build (x86_64-pc-windows-msvc, C modules)
+    runs-on: windows-latest
+    env:
+      LUA_VERSION: "5.4.8"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: x86_64-pc-windows-msvc-cmodules
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build shared lua54.dll
+        shell: cmd
+        run: |
+          curl -L -o lua.tar.gz https://www.lua.org/ftp/lua-%LUA_VERSION%.tar.gz || exit /b 1
+          tar -xzf lua.tar.gz || exit /b 1
+          cd lua-%LUA_VERSION%\src
+          cl /nologo /MD /O2 /c /DLUA_BUILD_AS_DLL *.c || exit /b 1
+          del lua.obj luac.obj
+          link /nologo /DLL /IMPLIB:lua54.lib /OUT:lua54.dll *.obj || exit /b 1
+
+      - name: Build (native)
+        shell: cmd
+        run: |
+          rem mlua-sys links against LUA_LIB_NAME in LUA_LIB; the C glue finds
+          rem lua.h via cl.exe's INCLUDE path, so prepend the Lua source dir.
+          set INCLUDE=%CD%\lua-%LUA_VERSION%\src;%INCLUDE%
+          set LUA_LIB=%CD%\lua-%LUA_VERSION%\src
+          set LUA_LIB_NAME=lua54
+          cargo build --release --locked --no-default-features --features scripting --target x86_64-pc-windows-msvc
+
+      - name: Package
+        shell: pwsh
+        run: |
+          $staging = "proxelar-cmodules"
+          New-Item -ItemType Directory -Path $staging | Out-Null
+          Copy-Item "target/x86_64-pc-windows-msvc/release/proxelar.exe" $staging
+          Copy-Item "lua-$env:LUA_VERSION/src/lua54.dll" $staging
+          Compress-Archive -Path "$staging/*" -DestinationPath "proxelar-${{ github.ref_name }}-x86_64-pc-windows-msvc-cmodules.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: proxelar-x86_64-pc-windows-msvc-cmodules
+          path: proxelar-${{ github.ref_name }}-x86_64-pc-windows-msvc-cmodules.zip
+
   release:
     name: Create release
-    needs: build
+    needs: [build, build-windows-cmodules]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add upstream HTTPS trust policy configuration for default roots, extra CA files, CA-only trust, and insecure debugging.
 - Accept HTTP/2 client connections in forward and reverse proxy modes while preserving HTTP/1.1 upstream forwarding invariants.
 - Emit visible flow events for Lua short-circuits, intercept drops, replay failures, and upstream proxy errors.
+- Add `--allow-c-modules` to let Lua scripts load native C modules such as lua-protobuf (unsafe mode, off by default); Windows ships a separate `-cmodules` release archive bundling `lua54.dll`.
 
 ## [0.4.4] - 2026-05-01
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -14,6 +14,7 @@ proxelar [OPTIONS]
 | `--addr` | `-b` | `127.0.0.1` | Bind address |
 | `--target` | `-t` | — | Upstream target URI (required for reverse mode) |
 | `--script` | `-s` | — | Path to a Lua script for request/response hooks |
+| `--allow-c-modules` | | off | Let scripts load native Lua C modules (e.g. `lua-protobuf`); runs the VM in unsafe mode |
 | `--gui-port` | | `8081` | Web GUI port (only used with `-i gui`) |
 | `--ca-dir` | | `~/.proxelar` | Directory for CA certificate and key files |
 | `--body-capture-limit` | | `free` | Maximum body bytes buffered for capture/editing; use `free`, `unlimited`, or `none` for unlimited |

--- a/docs/src/scripting/overview.md
+++ b/docs/src/scripting/overview.md
@@ -64,6 +64,18 @@ end
 
 Script errors are caught, logged, and the request passes through unchanged. A buggy script can never crash the proxy. Check the log output (set `RUST_LOG=debug` for details) to see script errors.
 
+## Native C modules
+
+By default the Lua VM runs in safe mode, which blocks native C modules — `require` of a C module fails with `can't load C modules in safe mode`. To use one (for example [`lua-protobuf`](https://github.com/starwing/lua-protobuf)), pass `--allow-c-modules`:
+
+```bash
+proxelar --script decode.lua --allow-c-modules
+```
+
+This runs the VM in unsafe mode: loaded modules execute unsandboxed native code in the proxy process, so only use it with scripts you trust. The module must target Lua 5.4 (the version proxelar embeds).
+
+On **Windows**, the standard release binary statically links Lua and cannot load C modules. Use the `…-cmodules` release archive instead, which links a shared `lua54.dll` bundled alongside the executable.
+
 ## Feature flag
 
 Lua scripting is behind the `scripting` feature flag, enabled by default. To build without it:

--- a/proxelar-cli/Cargo.toml
+++ b/proxelar-cli/Cargo.toml
@@ -14,8 +14,9 @@ categories = ["command-line-utilities", "development-tools", "network-programmin
 keywords = ["proxy", "mitm", "http", "https", "lua"]
 
 [features]
-default = ["scripting"]
+default = ["scripting", "vendored-lua"]
 scripting = ["proxyapi/scripting"]
+vendored-lua = ["proxyapi/vendored-lua"]
 
 [dependencies]
 proxyapi = { version = "0.4.5", path = "../proxyapi" }

--- a/proxelar-cli/build.rs
+++ b/proxelar-cli/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    // Export the dynamic symbol table so Lua C modules loaded at runtime can
+    // resolve the Lua C API from this executable; without `-rdynamic`, `require`
+    // of a C module fails on Unix with `undefined symbol: lua_*`.
+    let scripting = std::env::var_os("CARGO_FEATURE_SCRIPTING").is_some();
+    let unix = std::env::var_os("CARGO_CFG_UNIX").is_some();
+    if scripting && unix {
+        println!("cargo::rustc-link-arg-bins=-rdynamic");
+    }
+}

--- a/proxelar-cli/src/cli.rs
+++ b/proxelar-cli/src/cli.rs
@@ -43,6 +43,14 @@ pub struct Args {
     #[arg(short = 's', long = "script", value_name = "FILE")]
     pub script: Option<PathBuf>,
 
+    /// Allow Lua scripts to load native C modules (e.g. lua-protobuf).
+    ///
+    /// Runs the Lua VM in unsafe mode: loaded modules execute unsandboxed native
+    /// code in the proxy process. Only use with trusted scripts.
+    #[cfg(feature = "scripting")]
+    #[arg(long = "allow-c-modules")]
+    pub allow_c_modules: bool,
+
     /// Maximum body bytes buffered for capture/editing before passthrough (`free` for unlimited)
     #[arg(
         long = "body-capture-limit",

--- a/proxelar-cli/src/main.rs
+++ b/proxelar-cli/src/main.rs
@@ -59,6 +59,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         body_capture_limit: args.body_capture_limit.into_option(),
         #[cfg(feature = "scripting")]
         script_path: args.script,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: args.allow_c_modules,
         replay_rx: Some(replay_rx),
     };
 

--- a/proxyapi/Cargo.toml
+++ b/proxyapi/Cargo.toml
@@ -15,10 +15,14 @@ keywords = ["proxy", "mitm", "http", "https", "lua"]
 
 [features]
 default = []
-scripting = ["mlua"]
+scripting = ["dep:mlua"]
+# Statically link a vendored Lua 5.4. Disable (build the binary with
+# --no-default-features) to link a shared system Lua instead, which is required
+# to load native C modules on Windows.
+vendored-lua = ["mlua?/vendored"]
 
 [dependencies]
-mlua = { version = "0.11", features = ["lua54", "vendored", "send"], optional = true }
+mlua = { version = "0.11", features = ["lua54", "send"], optional = true }
 hyper = { version = "1.9", features = ["http1", "http2", "server", "client"] }
 hyper-util = { version = "0.1", features = ["tokio", "server-auto", "client-legacy", "http1", "http2"] }
 http = "1.2"

--- a/proxyapi/src/lib.rs
+++ b/proxyapi/src/lib.rs
@@ -3,7 +3,9 @@
 //! Provides HTTP/HTTPS forward and reverse proxy functionality with
 //! request/response interception via the [`HttpHandler`] trait.
 
-#![forbid(unsafe_code)]
+// `deny` rather than `forbid` so the single audited block in `scripting`
+// (mlua's `unsafe_new`, gated behind --allow-c-modules) can opt in locally.
+#![deny(unsafe_code)]
 
 pub mod body;
 pub mod ca;

--- a/proxyapi/src/proxy/mod.rs
+++ b/proxyapi/src/proxy/mod.rs
@@ -167,6 +167,12 @@ pub struct ProxyConfig {
     /// Optional path to a Lua script for request/response hooks.
     #[cfg(feature = "scripting")]
     pub script_path: Option<PathBuf>,
+    /// Allow the Lua script to load native C modules (e.g. `lua-protobuf`).
+    ///
+    /// This runs the VM in mlua's unsafe mode; see
+    /// [`ScriptEngine::new_allowing_c_modules`](crate::scripting::ScriptEngine::new_allowing_c_modules).
+    #[cfg(feature = "scripting")]
+    pub allow_c_modules: bool,
     /// Optional channel for receiving replay requests from the UI.
     pub replay_rx: Option<mpsc::Receiver<ProxiedRequest>>,
 }
@@ -207,7 +213,14 @@ impl Proxy {
             .as_ref()
             .map(|p| {
                 tracing::info!("Loading Lua script: {}", p.display());
-                ScriptEngine::new(p).map(Arc::new)
+                if self.config.allow_c_modules {
+                    tracing::warn!(
+                        "Lua C module loading is enabled; scripts run unsandboxed native code"
+                    );
+                    ScriptEngine::new_allowing_c_modules(p).map(Arc::new)
+                } else {
+                    ScriptEngine::new(p).map(Arc::new)
+                }
             })
             .transpose()?;
 
@@ -341,6 +354,8 @@ mod tests {
             body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
             #[cfg(feature = "scripting")]
             script_path: None,
+            #[cfg(feature = "scripting")]
+            allow_c_modules: false,
             replay_rx: None,
         };
 

--- a/proxyapi/src/scripting.rs
+++ b/proxyapi/src/scripting.rs
@@ -57,12 +57,25 @@ pub struct ScriptEngine {
 }
 
 impl ScriptEngine {
-    /// Create a new engine by loading and executing the given Lua script file.
+    /// Create a new engine, in mlua's safe mode, from the given Lua script file.
     ///
     /// The script should define `on_request(request)` and/or `on_response(request, response)`.
     pub fn new(script_path: &Path) -> Result<Self, crate::Error> {
-        let lua = Lua::new();
+        Self::load(script_path, Lua::new())
+    }
 
+    /// Like [`new`](Self::new), but the VM can load native Lua C modules
+    /// (e.g. `lua-protobuf`). This drops mlua's safety guarantees: a loaded
+    /// module runs unsandboxed native code in the proxy. Only use trusted scripts.
+    pub fn new_allowing_c_modules(script_path: &Path) -> Result<Self, crate::Error> {
+        // SAFETY: opt-in via `--allow-c-modules`; the operator accepts that
+        // scripts may load native modules that run outside Rust's guarantees.
+        #[allow(unsafe_code)]
+        let lua = unsafe { Lua::unsafe_new() };
+        Self::load(script_path, lua)
+    }
+
+    fn load(script_path: &Path, lua: Lua) -> Result<Self, crate::Error> {
         let script = std::fs::read_to_string(script_path).map_err(|e| {
             crate::Error::Script(format!(
                 "Failed to read script {}: {e}",
@@ -329,6 +342,39 @@ mod tests {
         f.write_all(script.as_bytes()).unwrap();
         f.flush().unwrap();
         ScriptEngine::new(f.path()).unwrap()
+    }
+
+    fn engine_from_script_with<F>(script: &str, build: F) -> Result<(), crate::Error>
+    where
+        F: FnOnce(&Path) -> Result<ScriptEngine, crate::Error>,
+    {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(script.as_bytes()).unwrap();
+        f.flush().unwrap();
+        build(f.path()).map(drop)
+    }
+
+    #[test]
+    fn test_safe_mode_blocks_c_modules() {
+        let err = engine_from_script_with(
+            r#"package.loadlib("whatever.so", "luaopen_whatever")"#,
+            ScriptEngine::new,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("safe mode"), "got: {err}");
+    }
+
+    #[test]
+    fn test_allowing_c_modules_exposes_loadlib() {
+        // Unsafe mode: the missing library fails on the file, not on safe mode.
+        let err = engine_from_script_with(
+            r#"assert(package.loadlib("./does-not-exist.so", "luaopen_x"))"#,
+            ScriptEngine::new_allowing_c_modules,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(!err.contains("safe mode"), "got: {err}");
     }
 
     #[test]

--- a/proxyapi/tests/forward_proxy.rs
+++ b/proxyapi/tests/forward_proxy.rs
@@ -37,6 +37,8 @@ async fn test_forward_proxy_starts_and_shuts_down() {
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -694,6 +696,8 @@ async fn start_forward_proxy() -> (
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -734,6 +738,8 @@ async fn start_forward_proxy_with_replay() -> (
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: Some(replay_rx),
     };
 

--- a/proxyapi/tests/reverse_proxy.rs
+++ b/proxyapi/tests/reverse_proxy.rs
@@ -35,6 +35,8 @@ async fn test_reverse_proxy_starts_and_shuts_down() {
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -77,6 +79,8 @@ async fn reverse_proxy_forwards_http_and_emits_request_complete() {
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -148,6 +152,8 @@ async fn reverse_proxy_forwards_h2c_post_and_emits_http2_capture() {
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -232,6 +238,8 @@ async fn reverse_proxy_returns_502_when_target_is_unreachable() {
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -362,6 +370,8 @@ async fn reverse_proxy_intercepts_oversized_request_before_streaming_original() 
         body_capture_limit: Some(4),
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -447,6 +457,8 @@ async fn reverse_proxy_intercept_drop_emits_request_complete() {
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -562,6 +574,7 @@ async fn reverse_proxy_runs_scripts_for_oversized_request_and_response() {
         intercept: None,
         body_capture_limit: Some(4),
         script_path: Some(script.path().to_path_buf()),
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -631,6 +644,7 @@ async fn reverse_proxy_lua_short_circuit_emits_request_complete() {
         intercept: None,
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         script_path: Some(script.path().to_path_buf()),
+        allow_c_modules: false,
         replay_rx: None,
     };
 
@@ -729,6 +743,8 @@ async fn request_private_ca_https_upstream(
         body_capture_limit: DEFAULT_BODY_CAPTURE_LIMIT,
         #[cfg(feature = "scripting")]
         script_path: None,
+        #[cfg(feature = "scripting")]
+        allow_c_modules: false,
         replay_rx: None,
     };
 


### PR DESCRIPTION
Closes #146.

## Problem

Scripts that `require` a native C module (e.g. [`lua-protobuf`](https://github.com/starwing/lua-protobuf)) fail with `can't load C modules in safe mode`, because the Lua VM is created with mlua's safe constructor which disables native module loading.

## Solution

An opt-in `--allow-c-modules` flag that runs the VM in mlua's unsafe mode, plus the linker/packaging work needed to make C modules actually loadable on each platform.

### Core
- `ScriptEngine::new_allowing_c_modules` builds the VM via `Lua::unsafe_new()`. The crate lint is relaxed from `forbid(unsafe_code)` to `deny` so the single audited block can opt in locally with a `SAFETY:` note (`forbid` cannot be overridden).
- The flag is threaded through `ProxyConfig` → script loader (with a runtime warning) → CLI.

### Linking (the part that makes `require` actually work)
- **Unix:** new `build.rs` emits `-rdynamic` so loaded C modules resolve the Lua C API from the executable (per the [mlua FAQ](https://github.com/mlua-rs/mlua/blob/main/FAQ.md); without it `require` fails with `undefined symbol: lua_*`).
- **Feature split:** vendoring moved into a `vendored-lua` feature (weak `mlua?/vendored`, on by default). `cargo install proxelar` stays vendored and portable everywhere; a `--no-default-features --features scripting` build links a shared system Lua instead.
- **Windows:** a dedicated release job compiles `lua54.dll` from source with MSVC, links proxelar against it (`LUA_LIB`/`LUA_LIB_NAME` + Lua headers on `INCLUDE`), and ships it as a `…-cmodules.zip` with the DLL bundled. The standard Windows binary stays statically linked and portable.

### Docs
- CLI reference row + a "Native C modules" section covering the flag, the trust caveat (modules run unsandboxed native code), the Lua 5.4 requirement, and the Windows `-cmodules` archive.

## Safety note

This intentionally drops mlua's safety guarantees when enabled: a loaded module runs unsandboxed native code in the proxy process. It is off by default, gated behind an explicit flag, and emits a warning when used.

## Testing
- New unit tests assert safe mode blocks C modules and unsafe mode exposes `package.loadlib`.
- Verified all feature configurations build (default/vendored, scripting-only/shared, vendored-only no-op, scripting-off), `cargo tree` confirms the weak-dependency resolution, clippy and fmt clean.
- ⚠️ The Windows `-cmodules` release job (Lua-from-source MSVC build) has not been exercised on a real runner yet — it will run on the next tagged release.