### PR TITLE
feat(cli): add --quiet flag to suppress per-request output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Accept HTTP/2 client connections in forward and reverse proxy modes while preserving HTTP/1.1 upstream forwarding invariants.
 - Emit visible flow events for Lua short-circuits, intercept drops, replay failures, and upstream proxy errors.
 - Add `--allow-c-modules` to let Lua scripts load native C modules such as lua-protobuf (unsafe mode, off by default); Windows ships a separate `-cmodules` release archive bundling `lua54.dll`.
+- Add a `--quiet` (`-q`) flag that suppresses per-request output in terminal mode, so Lua script `print()` output can be read on its own.
 
 ## [0.4.4] - 2026-05-01
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -15,6 +15,7 @@ proxelar [OPTIONS]
 | `--target` | `-t` | — | Upstream target URI (required for reverse mode) |
 | `--script` | `-s` | — | Path to a Lua script for request/response hooks |
 | `--allow-c-modules` | | off | Let scripts load native Lua C modules (e.g. `lua-protobuf`); runs the VM in unsafe mode |
+| `--quiet` | `-q` | | Suppress per-request output (only used with `-i terminal`) |
 | `--gui-port` | | `8081` | Web GUI port (only used with `-i gui`) |
 | `--ca-dir` | | `~/.proxelar` | Directory for CA certificate and key files |
 | `--body-capture-limit` | | `free` | Maximum body bytes buffered for capture/editing; use `free`, `unlimited`, or `none` for unlimited |
@@ -45,6 +46,9 @@ proxelar -m reverse --target http://localhost:3000 --script auth.lua
 
 # Forward proxy with logging script
 proxelar --script log_traffic.lua
+
+# Show only the script's print() output, no per-request lines
+proxelar -i terminal -q --script log_traffic.lua
 
 # Capture only the first 1 MiB of large bodies while streaming traffic through
 proxelar --body-capture-limit 1048576

--- a/docs/src/interfaces.md
+++ b/docs/src/interfaces.md
@@ -58,6 +58,12 @@ Prints each request/response as a colored line to stdout. Useful for quick inspe
 
 Output includes timestamp, HTTP method (color-coded), URL, status code, and response size.
 
+Pass `--quiet` (`-q`) to suppress the per-request lines; errors still go to stderr. This is useful with a [Lua script](scripting/overview.md) that produces its own output via `print()`:
+
+```bash
+proxelar -i terminal -q --script log_traffic.lua
+```
+
 ## Web GUI
 
 ```bash

--- a/docs/src/scripting/examples.md
+++ b/docs/src/scripting/examples.md
@@ -83,6 +83,8 @@ function on_response(request, response)
 end
 ```
 
+Run with `proxelar -i terminal -q --script log.lua` to see only the script's output, without the proxy's own per-request lines.
+
 ## Inject authentication
 
 ```lua

--- a/proxelar-cli/src/cli.rs
+++ b/proxelar-cli/src/cli.rs
@@ -51,6 +51,10 @@ pub struct Args {
     #[arg(long = "allow-c-modules")]
     pub allow_c_modules: bool,
 
+    /// Suppress per-request output (only used with -i terminal)
+    #[arg(short, long)]
+    pub quiet: bool,
+
     /// Maximum body bytes buffered for capture/editing before passthrough (`free` for unlimited)
     #[arg(
         long = "body-capture-limit",
@@ -126,6 +130,13 @@ mod tests {
             proxyapi::DEFAULT_BODY_CAPTURE_LIMIT
         );
         assert_eq!(args.upstream_trust, UpstreamTlsConfig::Default);
+    }
+
+    #[test]
+    fn test_quiet_flag() {
+        assert!(!Args::parse_from(["proxelar"]).quiet);
+        assert!(Args::parse_from(["proxelar", "-q"]).quiet);
+        assert!(Args::parse_from(["proxelar", "--quiet"]).quiet);
     }
 
     #[test]

--- a/proxelar-cli/src/interface/terminal.rs
+++ b/proxelar-cli/src/interface/terminal.rs
@@ -11,9 +11,11 @@ enum TerminalOutput {
     Ignore,
 }
 
-pub async fn run(mut event_rx: mpsc::Receiver<ProxyEvent>, cancel: CancellationToken) {
-    println!("{}", "Proxelar proxy running. Press Ctrl+C to stop.".bold());
-    println!();
+pub async fn run(mut event_rx: mpsc::Receiver<ProxyEvent>, quiet: bool, cancel: CancellationToken) {
+    if !quiet {
+        println!("{}", "Proxelar proxy running. Press Ctrl+C to stop.".bold());
+        println!();
+    }
 
     loop {
         let event = tokio::select! {
@@ -25,7 +27,8 @@ pub async fn run(mut event_rx: mpsc::Receiver<ProxyEvent>, cancel: CancellationT
         };
 
         match render_event(&event) {
-            TerminalOutput::Stdout(line) => println!("{line}"),
+            TerminalOutput::Stdout(line) if !quiet => println!("{line}"),
+            TerminalOutput::Stdout(_) => {}
             TerminalOutput::Stderr(line) => eprintln!("{line}"),
             TerminalOutput::Ignore => {}
         }
@@ -243,7 +246,7 @@ mod tests {
         .unwrap();
         drop(tx);
 
-        tokio::time::timeout(std::time::Duration::from_secs(1), run(rx, cancel))
+        tokio::time::timeout(std::time::Duration::from_secs(1), run(rx, false, cancel))
             .await
             .unwrap();
     }

--- a/proxelar-cli/src/main.rs
+++ b/proxelar-cli/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     match args.interface {
-        Interface::Terminal => interface::terminal::run(event_rx, cancel).await,
+        Interface::Terminal => interface::terminal::run(event_rx, args.quiet, cancel).await,
         Interface::Tui => {
             interface::tui::run(event_rx, Arc::clone(&intercept), replay_tx, cancel).await
         }


### PR DESCRIPTION
## Summary

Adds a `--quiet` (`-q`) flag for terminal mode (`-i terminal`) that suppresses the startup banner and the per-request lines, leaving stdout to the Lua script's `print()` output. Proxy errors still go to stderr.

This addresses the use case *"I only want to see the information printed by the script, not the information for each request"* — the same pattern mitmproxy supports with `mitmdump -q -s addon.py`.

## Changes

- `proxelar-cli/src/cli.rs`: new `quiet: bool` arg (+ parse test)
- `proxelar-cli/src/interface/terminal.rs`: `run()` takes `quiet` and skips stdout lines when set; `render_event()` stays untouched
- Docs: CLI reference, interfaces page, scripting examples
- Changelog entry under `[Unreleased]`

## Usage

```bash
proxelar -i terminal -q --script log_traffic.lua
```

## Testing

- `cargo test --workspace` — all 122 tests pass
- `cargo fmt --all --check` and `cargo clippy --workspace -- -D warnings` clean
- Manual smoke test: with `-q` and a script printing `[SCRIPT] METHOD URL`, stdout contained only the script lines for proxied requests