### PR TITLE
release: publish .deb packages for linux targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,12 @@ jobs:
             runner: ubuntu-latest
             cross: false
             archive: tar.gz
+            deb: true
           - target: aarch64-unknown-linux-gnu
             runner: ubuntu-latest
             cross: true
             archive: tar.gz
+            deb: true
           - target: x86_64-apple-darwin
             runner: macos-latest
             cross: false
@@ -70,6 +72,18 @@ jobs:
           cd target/${{ matrix.target }}/release
           tar czf ../../../proxelar-${{ github.ref_name }}-${{ matrix.target }}.tar.gz proxelar
           cd ../../..
+
+      - name: Install cargo-deb
+        if: matrix.deb
+        run: cargo install cargo-deb --locked
+
+      - name: Package (deb)
+        if: matrix.deb
+        # --no-build reuses the binary produced above. --no-strip because the
+        # runner's strip cannot process the cross-built aarch64 ELF.
+        run: |
+          cargo deb -p proxelar --target ${{ matrix.target }} --no-build --no-strip \
+            --output proxelar-${{ github.ref_name }}-${{ matrix.target }}.deb
 
       - name: Package (windows)
         if: matrix.archive == 'zip'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Publish `.deb` packages for `x86_64` and `aarch64` Linux alongside the existing release archives.
+
 ## [0.5.0] - 2026-07-25
 
 ### Added

--- a/proxelar-cli/Cargo.toml
+++ b/proxelar-cli/Cargo.toml
@@ -13,6 +13,28 @@ readme = "../README.md"
 categories = ["command-line-utilities", "development-tools", "network-programming"]
 keywords = ["proxy", "mitm", "http", "https", "lua"]
 
+[package.metadata.deb]
+maintainer = "Emanuele Micheletti <micheletti.emanuele@hotmail.com>"
+copyright = "2026, Emanuele Micheletti <micheletti.emanuele@hotmail.com>"
+license-file = ["../LICENSE-MIT", "0"]
+section = "net"
+priority = "optional"
+# OpenSSL and Lua are vendored, so only the C runtime is resolved dynamically.
+# Set explicitly rather than via `$auto`, which cannot run dpkg-shlibdeps when
+# the aarch64 binary is cross-built on an amd64 runner.
+depends = "libc6, libgcc-s1"
+extended-description = """
+Proxelar is a single-binary MITM proxy for inspecting, intercepting, replaying
+and rewriting HTTP, HTTPS and WebSocket traffic. It runs as an interactive TUI,
+plain terminal output, a web GUI, or a headless REST API, and supports forward,
+reverse, WireGuard, SOCKS5, DNS and fixed-target UDP capture modes, Lua hooks,
+declarative rules, and HAR/curl/raw export with secret redaction."""
+assets = [
+    ["target/release/proxelar", "usr/bin/", "755"],
+    ["../README.md", "usr/share/doc/proxelar/README.md", "644"],
+    ["../CHANGELOG.md", "usr/share/doc/proxelar/CHANGELOG.md", "644"],
+]
+
 [features]
 default = ["scripting", "vendored-lua"]
 scripting = ["proxyapi/scripting"]


### PR DESCRIPTION
Adds Debian packages to the release artifacts, so Debian-family distributions (and Kali in particular) can consume a prebuilt package instead of building from source.

## What changed

- `proxelar-cli/Cargo.toml`: a `[package.metadata.deb]` section describing the package (section `net`, priority `optional`, MIT copyright from `LICENSE-MIT`, README and CHANGELOG installed under `/usr/share/doc/proxelar/`).
- `.github/workflows/release.yml`: the two Linux matrix entries now carry `deb: true`, and build a `.deb` with `cargo-deb` after the existing build step. The existing upload glob already picks the files up, so they flow into the checksums, the SBOM, the attestation and the release automatically.

## Notes on the two non-obvious flags

- `--no-build` reuses the binary produced by the earlier build step rather than compiling a second time.
- `--no-strip` is required because the runner's `strip` cannot process the cross-built `aarch64` ELF.

`depends` is set explicitly to `libc6, libgcc-s1` rather than left as `$auto`. OpenSSL and Lua are vendored, so the C runtime is the only dynamic dependency, and `$auto` would invoke `dpkg-shlibdeps`, which cannot resolve an aarch64 binary on an amd64 runner.

## Verification

Built a package locally with `cargo deb --no-build --no-strip` and inspected the result. Control file:

```
Package: proxelar
Version: 0.5.0-1
Section: net
Priority: optional
Depends: libc6, libgcc-s1
```

Payload: `/usr/bin/proxelar` plus `/usr/share/doc/proxelar/{README.md,CHANGELOG.md,copyright}`. The workflow YAML parses and `deb: true` is set only on the two Linux targets.