### PR TITLE
docs: document winget and Docker installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 
 - Publish `.deb` packages for `x86_64` and `aarch64` Linux alongside the existing release archives.
+- Document winget as an installation channel now that the package is available on the Windows Package Manager.
 
 ## [0.5.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Publish `.deb` packages for `x86_64` and `aarch64` Linux alongside the existing release archives.
 - Document winget as an installation channel now that the package is available on the Windows Package Manager.
+- Document Docker/Podman on the installation page, which previously listed it only in the README.
 
 ## [0.5.0] - 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Proxelar is intentionally developer-oriented: terminal-first, scriptable, Rust-n
 
 ## Why use it?
 
-- **One local binary** — install with Homebrew, Cargo, Docker/Podman, or GitHub releases.
+- **One local binary** — install with Homebrew, winget, Cargo, Docker/Podman, or GitHub releases.
 - **Four interfaces** — TUI, plain terminal output, browser GUI, or a headless REST API.
 - **Lua scripting** — `on_request` and `on_response` hooks can rewrite, block, short-circuit, or mock traffic.
 - **Interactive intercept** — pause requests, edit method/URI/headers/body, forward, drop, or replay.
@@ -55,6 +55,12 @@ Proxelar is intentionally developer-oriented: terminal-first, scriptable, Rust-n
 
 ```bash
 brew install proxelar
+```
+
+### winget (Windows)
+
+```bash
+winget install --id EmanueleMicheletti.Proxelar --exact
 ```
 
 ### Cargo

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -6,6 +6,12 @@
 brew install proxelar
 ```
 
+## winget (Windows)
+
+```bash
+winget install --id EmanueleMicheletti.Proxelar --exact
+```
+
 ## From crates.io
 
 ```bash

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -12,6 +12,24 @@ brew install proxelar
 winget install --id EmanueleMicheletti.Proxelar --exact
 ```
 
+## Docker / Podman
+
+```bash
+# Web GUI
+docker run --rm -it -v ~/.proxelar:/root/.proxelar -p 8080:8080 -p 127.0.0.1:8081:8081 ghcr.io/emanuele-em/proxelar --interface gui --addr 0.0.0.0
+
+# Terminal
+docker run --rm -it -v ~/.proxelar:/root/.proxelar -p 8080:8080 ghcr.io/emanuele-em/proxelar --interface terminal --addr 0.0.0.0
+```
+
+The `-v ~/.proxelar:/root/.proxelar` mount reuses your existing trusted CA certificate, so you do not get browser warnings after trusting the CA once.
+
+The published image is `linux/amd64`. To build it yourself, or to run on another architecture, use the `Dockerfile` in the repository:
+
+```bash
+docker build -t proxelar .
+```
+
 ## From crates.io
 
 ```bash


### PR DESCRIPTION
Two gaps in the installation docs.

## winget

Proxelar is now in the Windows Package Manager community repository ([winget-pkgs#409656](https://github.com/microsoft/winget-pkgs/pull/409656), merged 2026-07-30), so the docs should say so.

- `README.md`: a winget section between Homebrew and Cargo, and winget added to the "One local binary" bullet that enumerates the channels.
- `docs/src/installation.md`: the same section, in the same position.

Uses the explicit form `winget install --id EmanueleMicheletti.Proxelar --exact`. The manifest also declares `Moniker: proxelar`, so the shorter `winget install proxelar` should resolve too, but that could not be verified from a non-Windows machine and the search index had not picked the package up yet at the time of writing. It can be shortened later once confirmed.

## Docker

`docs/src/installation.md` never mentioned Docker, even though the README documents it. The section is now mirrored there, plus a note that the published image is `linux/amd64` and a `docker build` fallback for other architectures.

Note that the image itself only starts existing once #168 lands: it was never actually published. That PR adds the missing release job, so these instructions become true from the next tagged release onward. The README already made this promise, so this change does not widen the gap, it just documents the same thing in both places.

Scoop is deliberately not documented yet, since [ScoopInstaller/Extras#18416](https://github.com/ScoopInstaller/Extras/pull/18416) is still open.