### PR TITLE
ci: publish the container image to ghcr on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,3 +205,56 @@ jobs:
           create-pullrequest: true
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_CORE_TOKEN }}
+
+  container:
+    name: Publish container image
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Collect image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+
+      # linux/amd64 only for now: the Dockerfile compiles the workspace from
+      # source, and building vendored OpenSSL and Lua for arm64 under QEMU
+      # emulation risks exceeding the job timeout on every release.
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@
 ### Added
 
 - Publish `.deb` packages for `x86_64` and `aarch64` Linux alongside the existing release archives.
+- Publish the container image to `ghcr.io/emanuele-em/proxelar` on every release, with build provenance attestation.
 - Document winget as an installation channel now that the package is available on the Windows Package Manager.
 - Document Docker/Podman on the installation page, which previously listed it only in the README.
+
+### Fixed
+
+- Build the container image with `--locked` so it resolves the same dependency versions as the released binaries.
 
 ## [0.5.0] - 2026-07-25
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 COPY . .
 
-RUN cargo build --release --workspace
+RUN cargo build --release --locked --workspace
 
 # ---- runtime ----
 FROM debian:bookworm-slim


### PR DESCRIPTION
The README tells people to run `ghcr.io/emanuele-em/proxelar`, but that image has never been published: no workflow pushes to ghcr, the packages API returns 404 for the owner, and the registry refuses a pull token for it while the same request against a known public image (`ghcr.io/astral-sh/uv`) returns a full tag list. So the documented Docker instructions currently fail for everyone.

This adds the missing half.

## What it does

A `container` job in the release workflow, running after `release` like `publish` and `homebrew` already do:

- logs in to ghcr with the built-in `GITHUB_TOKEN` (`packages: write`),
- derives tags with `docker/metadata-action`: the full version, `major.minor`, and `latest` only for non-prereleases, matching the `contains(github.ref_name, '-')` convention used elsewhere in this file,
- builds from the existing `Dockerfile` and pushes,
- attests build provenance and pushes the attestation to the registry, consistent with the SBOM and attestation already produced for the release archives.

## Two decisions worth flagging

**linux/amd64 only.** The Dockerfile compiles the workspace from source, including vendored OpenSSL and Lua. Building that for arm64 under QEMU emulation would add a long, failure-prone step to every release. If arm64 images are wanted, the cheaper route is a runtime-only Dockerfile that copies the aarch64 binary the release job already produces, which is a separate change.

**`--locked` added to the Dockerfile build.** It was building with `cargo build --release --workspace`, so the image could resolve different dependency versions than the released binaries built with `--locked`. Now they match.

## Not verified

No Docker daemon was available where this was written, so the image build was not executed locally; the workflow YAML parses and the job wiring was checked. The first tagged release will be the real test.

Unrelated but noticed while investigating: the 0.4.1 changelog entry promises an "official `Dockerfile` and `compose.yml`", and `compose.yml` is not in the repository.