### PR TITLE
chore: add justfile task runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Update dependencies to address the `h2` empty DATA frame denial of service and the `event-listener` and `lru` soundness advisories, and replace a yanked `chacha20` release.
+
 ## [0.5.1] - 2026-07-31
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ cargo clippy --workspace --all-targets --all-features
 cargo package --workspace --list
 ```
 
+If you have [`just`](https://github.com/casey/just) installed (`brew install just` or `cargo install just`), `justfile` wraps the commands above as recipes (`just test`, `just lint`, `just check` for the full local gate, etc.) — run `just --list` to see all of them. It's optional; every recipe is a thin wrapper around the plain `cargo` commands documented here and below.
+
 ## Making Changes
 
 1. Fork the repo and create a branch from `main`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -574,15 +574,6 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1001,11 +992,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1268,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1876,9 +1866,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -2642,7 +2632,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]

--- a/justfile
+++ b/justfile
@@ -1,0 +1,89 @@
+# proxelar task runner
+
+coverage_min_lines := "80"
+core_coverage_target_lines := "90"
+
+# Run the full workspace test suite
+test:
+    cargo test --workspace --locked
+
+# Run tests for a single crate, e.g. `just test-crate proxyapi`
+test-crate crate:
+    cargo test -p {{ crate }} --locked
+
+# Run proxyapi's scripting-gated tests, self-contained via vendored Lua
+test-scripting:
+    cargo test -p proxyapi --locked --features scripting,vendored-lua -- scripting
+
+# Run the workspace test suite with default features disabled
+test-no-default-features:
+    cargo test --workspace --locked --no-default-features
+
+# Run fast local lint checks
+lint:
+    cargo fmt --all --check
+    cargo clippy --workspace --all-targets --all-features
+
+# Build the workspace
+build:
+    cargo build --workspace --locked
+
+# Build the workspace in release mode
+build-release:
+    cargo build --workspace --locked --release
+
+# Build the workspace with default features disabled (Lua scripting off)
+build-no-default-features:
+    cargo build --workspace --locked --no-default-features
+
+# Verify package tarball construction
+package:
+    cargo package --workspace --locked --no-verify
+
+# Build workspace docs, matching CI's warnings-as-errors gate
+doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
+
+# Install cargo-deny (one-time setup for the deny recipe below)
+deny-setup:
+    cargo install cargo-deny --locked
+
+# Check dependency licenses, bans and advisories (matches CI's deny.yml)
+deny:
+    cargo deny check
+
+# Install cargo-audit (one-time setup for the audit recipe below)
+audit-setup:
+    cargo install cargo-audit --locked
+
+# Scan dependencies for RustSec advisories (matches CI's audit job)
+audit:
+    cargo audit
+
+# Full local gate before large changes (lint, build, test, package, doc, audit)
+check: lint build build-no-default-features test test-no-default-features package doc audit
+
+# Install cargo-llvm-cov (one-time setup for the coverage recipes below)
+coverage-setup:
+    cargo install cargo-llvm-cov --locked
+
+# Workspace coverage gate matching CI (80%+ line coverage)
+coverage:
+    cargo llvm-cov --workspace --all-features --locked \
+        --ignore-filename-regex '(^|/)(tests|target)/' \
+        --fail-under-lines {{ coverage_min_lines }}
+
+# Full CI coverage gate: workspace 80%+, then proxyapi core crate 90%+
+coverage-check: coverage
+    cargo llvm-cov report -p proxyapi \
+        --ignore-filename-regex '(^|/)(tests|target)/' \
+        --fail-under-lines {{ core_coverage_target_lines }}
+
+# Browsable HTML coverage report
+coverage-html:
+    cargo llvm-cov --workspace --all-features --locked --html \
+        --ignore-filename-regex '(^|/)(tests|target)/'
+
+# Run the built binary against the current build (TUI by default; pass args to select another mode)
+run *args:
+    cargo run -- {{ args }}

--- a/justfile
+++ b/justfile
@@ -85,5 +85,6 @@ coverage-html:
         --ignore-filename-regex '(^|/)(tests|target)/'
 
 # Run the built binary against the current build (TUI by default; pass args to select another mode)
+[positional-arguments]
 run *args:
-    cargo run -- {{ args }}
+    cargo run -- "$@"

--- a/proxelar-cli/src/interface/tui/handler.rs
+++ b/proxelar-cli/src/interface/tui/handler.rs
@@ -324,7 +324,9 @@ fn parse_edited_http_request(
     }
     let decoded = compact
         .as_bytes()
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             let pair = std::str::from_utf8(pair).map_err(|_| "Invalid hex body")?;
             u8::from_str_radix(pair, 16).map_err(|_| "Invalid hex body")


### PR DESCRIPTION
Wraps the cargo commands documented in CONTRIBUTING.md as recipes (test, lint, build, check for the full local gate, coverage gates, etc.). Optional — every recipe is a thin wrapper, nothing changes for contributors who don't use just.

## Changelog
- [x] I have added an entry to `CHANGELOG.md` under `[Unreleased]`, or this PR does not need one

## Tests
- [x] I have added or updated tests for user-visible behavior changes, or this PR does not need tests
