### PR TITLE
feat(cli): Honor $XDG_CONFIG_HOME for --ca-dir default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Honor `$XDG_CONFIG_HOME` when resolving the directory holding the CA certificate/key, addons, and other proxelar state. When the variable is set to a non-empty absolute path, state lives in `$XDG_CONFIG_HOME/proxelar`; otherwise `~/.proxelar` is used as before. `--ca-dir` still overrides both. If `$XDG_CONFIG_HOME` points somewhere new while an existing `~/.proxelar` is present, proxelar prints a warning naming both directories, since state is not migrated.
+
 ## [0.5.1] - 2026-07-31
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get update && apt-get install -y \
 
 COPY --from=builder /app/target/release/proxelar /usr/local/bin/proxelar
 
+# The container stores state at /root/.proxelar. Setting XDG_CONFIG_HOME or
+# passing --ca-dir moves it elsewhere, in which case mount that path instead.
 VOLUME /root/.proxelar
 
 EXPOSE 8080 8081

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ docker run --rm -it -v ~/.proxelar:/root/.proxelar -p 8080:8080 -p 127.0.0.1:808
 docker run --rm -it -v ~/.proxelar:/root/.proxelar -p 8080:8080 ghcr.io/emanuele-em/proxelar --interface terminal --addr 0.0.0.0
 ```
 
-The `-v ~/.proxelar:/root/.proxelar` mount reuses your existing trusted CA certificate so you do not get browser warnings after trusting the CA once.
+The `-v ~/.proxelar:/root/.proxelar` mount reuses your existing trusted CA certificate so you do not get browser warnings after trusting the CA once. The container always keeps its state at `/root/.proxelar`; if your host state directory differs (because `XDG_CONFIG_HOME` is set), mount that path instead of `~/.proxelar`.
 
 ---
 
@@ -187,7 +187,7 @@ proxelar -m wireguard -b 0.0.0.0 -p 51820 \
 | `-b, --addr` | Bind address | `127.0.0.1` |
 | `-t, --target` | Upstream URI for reverse or `HOST:PORT` for UDP | — |
 | `--gui-port` | Web GUI port | `8081` |
-| `--ca-dir` | CA certificate directory | `~/.proxelar` |
+| `--ca-dir` | Directory for CA cert/key, addons, and other proxelar state | `$XDG_CONFIG_HOME/proxelar` if set, else `~/.proxelar` |
 | `-s, --script` | Lua script file or addon directory (`init.lua`) | — |
 | `--addon` | Load a validated installed addon by name | — |
 | `--addons-dir` | Local addon catalog used by runtime and `addon` commands | `CA_DIR/addons` |
@@ -204,6 +204,29 @@ proxelar -m wireguard -b 0.0.0.0 -p 51820 \
 </details>
 
 `--upstream-trust insecure` disables upstream certificate and hostname verification. Use it only for controlled debugging.
+
+---
+
+## Configuration
+
+Proxelar keeps its CA certificate/key, addons, and other local state in one directory, resolved in this order:
+
+1. `--ca-dir <DIR>` — explicit override, always wins
+2. `$XDG_CONFIG_HOME/proxelar` — used when that env var is set to a non-empty absolute path
+3. `~/.proxelar` — default when neither of the above applies
+
+```bash
+# Uses ~/.proxelar (no XDG_CONFIG_HOME set)
+proxelar
+
+# Uses $XDG_CONFIG_HOME/proxelar, e.g. ~/.config/proxelar
+XDG_CONFIG_HOME=~/.config proxelar
+
+# Always uses the given path, regardless of XDG_CONFIG_HOME
+proxelar --ca-dir /path/to/proxelar-state
+```
+
+This directory isn't just for the CA certificate — addons and other local proxelar state live there too, so pointing `--ca-dir` (or `XDG_CONFIG_HOME`) somewhere else moves everything at once, not just certs.
 
 ---
 

--- a/docs/src/ca-certificate.md
+++ b/docs/src/ca-certificate.md
@@ -4,12 +4,14 @@ Proxelar intercepts HTTPS traffic by generating a local Certificate Authority (C
 
 ## Automatic generation
 
-On first run, Proxelar generates a 4096-bit RSA CA certificate and private key in `~/.proxelar/`:
+On first run, Proxelar generates a 4096-bit RSA CA certificate and private key in its state directory:
 
-- `~/.proxelar/proxelar-ca.pem` — CA certificate
-- `~/.proxelar/proxelar-ca.key` — CA private key (mode 0600)
+- `proxelar-ca.pem` — CA certificate
+- `proxelar-ca.key` — CA private key (mode 0600)
 
 If these files already exist, they are reused.
+
+> The paths on this page assume the default state directory. If `XDG_CONFIG_HOME` is set, or you pass `--ca-dir`, substitute that directory for `~/.proxelar` throughout. See [state directory precedence](./cli-reference.md#state-directory-precedence).
 
 ## Certificate download server
 
@@ -68,7 +70,7 @@ proxelar --ca-dir /path/to/certs
 
 ## Removing the CA
 
-When you are done, remove the Proxelar CA from every trust store where you installed it. The generated files live in `~/.proxelar/` by default, but deleting those files does not remove trust from your OS, browser, or mobile device.
+When you are done, remove the Proxelar CA from every trust store where you installed it. The generated files live in the state directory (`~/.proxelar/` by default), but deleting those files does not remove trust from your OS, browser, or mobile device.
 
 See [CA trust and uninstall](./guides/ca-trust.md) for platform-specific uninstall notes and limitations such as certificate pinning.
 

--- a/docs/src/cli-reference.md
+++ b/docs/src/cli-reference.md
@@ -19,7 +19,7 @@ proxelar addon <list|inspect|verify|install> [OPTIONS]
 | `--addons-dir` | | `CA_DIR/addons` | Local addon catalog used by runtime and addon commands |
 | `--quiet` | `-q` | | Suppress per-request output (only used with `-i terminal`) |
 | `--gui-port` | | `8081` | Web GUI port (only used with `-i gui`) |
-| `--ca-dir` | | `~/.proxelar` | Directory for CA certificate and key files |
+| `--ca-dir` | | `$XDG_CONFIG_HOME/proxelar` if set, else `~/.proxelar` | Directory for CA certificate/key, addons, and other proxelar state |
 | `--body-capture-limit` | | `free` | Maximum body bytes buffered for capture/editing; use `free`, `unlimited`, or `none` for unlimited |
 | `--upstream-trust` | | `default` | Upstream TLS trust policy: `default`, `default+ca:/path/ca.pem`, `ca-only:/path/ca.pem`, or `insecure` |
 | `--upstream-proxy` | | — | Chain traffic through `http://HOST:PORT` or `socks5://HOST:PORT` |
@@ -47,6 +47,17 @@ proxelar addon <list|inspect|verify|install> [OPTIONS]
 | Variable | Description |
 |----------|-------------|
 | `RUST_LOG` | Controls log verbosity. Examples: `debug`, `proxyapi=trace`, `warn` |
+| `XDG_CONFIG_HOME` | When set to a non-empty absolute path, proxelar keeps its state in `$XDG_CONFIG_HOME/proxelar` |
+
+### State directory precedence
+
+Proxelar keeps its CA certificate/key, addons, and other local state in one directory, resolved in this order:
+
+1. `--ca-dir <DIR>` — explicit override, always wins
+2. `$XDG_CONFIG_HOME/proxelar` — used when that env var is set to a non-empty absolute path (relative values are ignored, per the XDG base directory spec)
+3. `~/.proxelar` — default when neither of the above applies
+
+State is never migrated between these locations. If `XDG_CONFIG_HOME` points somewhere new while an old `~/.proxelar` still exists, proxelar logs a warning and generates a fresh CA; pass `--ca-dir ~/.proxelar` to keep using the existing one.
 
 ## Examples
 

--- a/docs/src/guides/browser-curl.md
+++ b/docs/src/guides/browser-curl.md
@@ -44,7 +44,7 @@ http://proxel.ar
 
 Download and trust the Proxelar CA using the instructions shown on that page. After the CA is trusted, HTTPS pages should appear in Proxelar.
 
-Firefox uses its own certificate store unless configured to use the system store. Import `~/.proxelar/proxelar-ca.pem` in Firefox settings if HTTPS traffic still shows certificate warnings.
+Firefox uses its own certificate store unless configured to use the system store. Import `proxelar-ca.pem` from the state directory (`~/.proxelar` by default) in Firefox settings if HTTPS traffic still shows certificate warnings.
 
 ## Troubleshooting
 

--- a/docs/src/guides/ca-trust.md
+++ b/docs/src/guides/ca-trust.md
@@ -13,6 +13,8 @@ By default, Proxelar stores the CA files in:
 
 The private key stays on your machine. Anyone with the key can mint certificates trusted by clients where you installed the CA, so treat it as sensitive.
 
+If `XDG_CONFIG_HOME` is set, or you pass `--ca-dir`, the files live in that directory instead. See [state directory precedence](../cli-reference.md#state-directory-precedence).
+
 ## Install through the built-in page
 
 Start Proxelar, configure your browser or device to use `127.0.0.1:8080`, then visit:
@@ -33,7 +35,7 @@ Remove trust from every place where you installed the CA:
 - **Firefox**: remove it from Settings > Privacy & Security > Certificates > View Certificates.
 - **iOS/Android**: remove the installed profile or user CA from system settings.
 
-After trust is removed, deleting `~/.proxelar/` removes Proxelar's local copy of the certificate and key.
+After trust is removed, deleting the state directory (`~/.proxelar/` by default) removes Proxelar's local copy of the certificate and key.
 
 ## Limitations
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -22,7 +22,7 @@ docker run --rm -it -v ~/.proxelar:/root/.proxelar -p 8080:8080 -p 127.0.0.1:808
 docker run --rm -it -v ~/.proxelar:/root/.proxelar -p 8080:8080 ghcr.io/emanuele-em/proxelar --interface terminal --addr 0.0.0.0
 ```
 
-The `-v ~/.proxelar:/root/.proxelar` mount reuses your existing trusted CA certificate, so you do not get browser warnings after trusting the CA once.
+The `-v ~/.proxelar:/root/.proxelar` mount reuses your existing trusted CA certificate, so you do not get browser warnings after trusting the CA once. The container always keeps its state at `/root/.proxelar`; if your host state directory differs (because `XDG_CONFIG_HOME` is set), mount that path instead of `~/.proxelar`.
 
 The published image is `linux/amd64`. To build it yourself, or to run on another architecture, use the `Dockerfile` in the repository:
 

--- a/docs/src/proxy-modes/wireguard-socks-dns.md
+++ b/docs/src/proxy-modes/wireguard-socks-dns.md
@@ -7,7 +7,7 @@ proxelar -m wireguard -b 0.0.0.0 -p 51820 \
   --wireguard-endpoint 192.168.1.10:51820
 ```
 
-WireGuard mode accepts a mobile or IoT device without firewall rules or system-proxy configuration. On first start it creates owner-only server/client keys and `~/.proxelar/proxelar-wg.conf`. The TUI and authenticated web GUI show the profile as a scannable QR code while the capture is empty; terminal mode prints the same QR at startup. You can also import the file directly. The short `proxelar-wg` profile name stays within Android's 15-character WireGuard interface-name limit.
+WireGuard mode accepts a mobile or IoT device without firewall rules or system-proxy configuration. On first start it creates owner-only server/client keys and `proxelar-wg.conf` in the state directory (`~/.proxelar` by default). The TUI and authenticated web GUI show the profile as a scannable QR code while the capture is empty; terminal mode prints the same QR at startup. You can also import the file directly. The short `proxelar-wg` profile name stays within Android's 15-character WireGuard interface-name limit.
 
 The QR code contains the client private key. Display it only on a trusted screen. It disappears from the TUI and web GUI after the first captured event, although the configuration file remains available for later import.
 

--- a/docs/src/quick-start.md
+++ b/docs/src/quick-start.md
@@ -12,7 +12,7 @@ This starts Proxelar in forward proxy mode with the interactive TUI on `127.0.0.
 
 Configure your system or browser proxy to `127.0.0.1:8080`, then visit [http://proxel.ar](http://proxel.ar) through the proxy. The page provides direct certificate downloads and platform-specific installation instructions.
 
-Alternatively, manually install `~/.proxelar/proxelar-ca.pem`. See [CA Certificate](./ca-certificate.md) for all platforms.
+Alternatively, manually install `proxelar-ca.pem` from the state directory (`~/.proxelar` by default). See [CA Certificate](./ca-certificate.md) for all platforms.
 
 ## 3. Browse through the proxy
 

--- a/docs/src/reference/threat-model.md
+++ b/docs/src/reference/threat-model.md
@@ -8,7 +8,7 @@ The highest-value assets are the root CA private key, captured authorization/coo
 
 ## Local CA
 
-The CA private key can mint certificates trusted by any client that installs the root. Keep `~/.proxelar` private, never share `proxelar-ca.key`, and remove the root from client trust stores when Proxelar is no longer used. Each generated leaf certificate has a distinct private key rather than reusing the CA key.
+The CA private key can mint certificates trusted by any client that installs the root. Keep the state directory (`~/.proxelar` by default) private, never share `proxelar-ca.key`, and remove the root from client trust stores when Proxelar is no longer used. Each generated leaf certificate has a distinct private key rather than reusing the CA key.
 
 Certificate-pinned clients will reject interception. Android 7+ applications trust user-installed CAs only when their network security configuration opts in. See [CA trust and uninstall](../guides/ca-trust.md).
 

--- a/proxelar-cli/src/ca_dir.rs
+++ b/proxelar-cli/src/ca_dir.rs
@@ -1,0 +1,220 @@
+//! Resolution of the directory holding CA certs, addons, and browser profile.
+
+use std::path::{Path, PathBuf};
+
+/// Which precedence rule produced the resolved directory.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Source {
+    CliArg,
+    XdgConfigHome,
+    HomeDefault,
+}
+
+/// Resolve the CA/addons/browser-profile directory.
+///
+/// Precedence: `--ca-dir` CLI flag > `$XDG_CONFIG_HOME/proxelar` (when the
+/// env var is set to a non-empty absolute path) > `~/.proxelar`.
+pub fn resolve_ca_dir(cli_arg: Option<PathBuf>) -> PathBuf {
+    let home = dirs::home_dir();
+    let legacy = home.as_ref().map(|h| h.join(".proxelar"));
+    let (dir, source) =
+        resolve_ca_dir_from_parts(cli_arg, std::env::var_os("XDG_CONFIG_HOME"), home);
+
+    if let Some(legacy) = legacy.as_deref() {
+        if should_warn_relocation(&dir, source, Some(legacy), |p| p.exists()) {
+            // Printed rather than logged: the default RUST_LOG filter hides warnings,
+            // and silently regenerating the CA is exactly what needs explaining.
+            eprintln!(
+                "warning: using {} because XDG_CONFIG_HOME is set, but an existing proxelar \
+                 directory was found at {}. Its CA certificate, addons, and WireGuard config \
+                 are not used. Pass --ca-dir {} to keep using it.",
+                dir.display(),
+                legacy.display(),
+                legacy.display(),
+            );
+        }
+    }
+    dir
+}
+
+fn resolve_ca_dir_from_parts(
+    cli_arg: Option<PathBuf>,
+    xdg_config_home: Option<std::ffi::OsString>,
+    home: Option<PathBuf>,
+) -> (PathBuf, Source) {
+    if let Some(dir) = cli_arg {
+        return (dir, Source::CliArg);
+    }
+    if let Some(xdg) = usable_xdg_config_home(xdg_config_home) {
+        return (xdg.join("proxelar"), Source::XdgConfigHome);
+    }
+    let dir = home
+        .unwrap_or_else(|| {
+            tracing::warn!("Could not determine home directory, using current directory");
+            PathBuf::from(".")
+        })
+        .join(".proxelar");
+    (dir, Source::HomeDefault)
+}
+
+/// The XDG basedir spec requires `$XDG_CONFIG_HOME` to be an absolute path and
+/// says relative values must be ignored, as must an empty one.
+fn usable_xdg_config_home(value: Option<std::ffi::OsString>) -> Option<PathBuf> {
+    let value = value.filter(|v| !v.is_empty())?;
+    let path = PathBuf::from(value);
+    if path.is_absolute() {
+        return Some(path);
+    }
+    // Printed rather than logged, for the same reason as the relocation notice above.
+    eprintln!(
+        "warning: ignoring XDG_CONFIG_HOME={}: the XDG base directory spec requires an \
+         absolute path.",
+        path.display()
+    );
+    None
+}
+
+/// True when `$XDG_CONFIG_HOME` silently moves us off an existing `~/.proxelar`.
+///
+/// State is never migrated, so without a warning the user just gets a fresh,
+/// untrusted CA and an empty addon catalog with no explanation.
+fn should_warn_relocation(
+    resolved: &Path,
+    source: Source,
+    legacy: Option<&Path>,
+    exists: impl Fn(&Path) -> bool,
+) -> bool {
+    source == Source::XdgConfigHome
+        && legacy.is_some_and(|legacy| legacy != resolved && exists(legacy))
+        && !exists(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_arg_wins_over_everything() {
+        let (dir, source) = resolve_ca_dir_from_parts(
+            Some(PathBuf::from("/explicit")),
+            Some("/xdg".into()),
+            Some(PathBuf::from("/home")),
+        );
+        assert_eq!(dir, PathBuf::from("/explicit"));
+        assert_eq!(source, Source::CliArg);
+    }
+
+    #[test]
+    fn uses_xdg_config_home_when_set() {
+        let (dir, source) =
+            resolve_ca_dir_from_parts(None, Some("/xdg".into()), Some(PathBuf::from("/home")));
+        assert_eq!(dir, PathBuf::from("/xdg/proxelar"));
+        assert_eq!(source, Source::XdgConfigHome);
+    }
+
+    #[test]
+    fn ignores_empty_xdg_config_home() {
+        let (dir, source) =
+            resolve_ca_dir_from_parts(None, Some("".into()), Some(PathBuf::from("/home")));
+        assert_eq!(dir, PathBuf::from("/home/.proxelar"));
+        assert_eq!(source, Source::HomeDefault);
+    }
+
+    #[test]
+    fn ignores_relative_xdg_config_home() {
+        let (dir, source) = resolve_ca_dir_from_parts(
+            None,
+            Some("relative/config".into()),
+            Some(PathBuf::from("/home")),
+        );
+        assert_eq!(dir, PathBuf::from("/home/.proxelar"));
+        assert_eq!(source, Source::HomeDefault);
+    }
+
+    #[test]
+    fn falls_back_to_home_proxelar_without_xdg() {
+        let (dir, source) = resolve_ca_dir_from_parts(None, None, Some(PathBuf::from("/home")));
+        assert_eq!(dir, PathBuf::from("/home/.proxelar"));
+        assert_eq!(source, Source::HomeDefault);
+    }
+
+    /// Existence predicate that reports true only for the listed paths.
+    fn existing(paths: &[&str]) -> impl Fn(&Path) -> bool + 'static {
+        let paths: Vec<PathBuf> = paths.iter().map(PathBuf::from).collect();
+        move |p| paths.iter().any(|e| e == p)
+    }
+
+    const XDG: &str = "/xdg/proxelar";
+    const LEGACY: &str = "/home/.proxelar";
+
+    #[test]
+    fn warns_when_xdg_is_new_and_legacy_dir_exists() {
+        assert!(should_warn_relocation(
+            Path::new(XDG),
+            Source::XdgConfigHome,
+            Some(Path::new(LEGACY)),
+            existing(&[LEGACY]),
+        ));
+    }
+
+    #[test]
+    fn silent_when_legacy_dir_absent() {
+        assert!(!should_warn_relocation(
+            Path::new(XDG),
+            Source::XdgConfigHome,
+            Some(Path::new(LEGACY)),
+            existing(&[]),
+        ));
+    }
+
+    #[test]
+    fn silent_when_xdg_dir_already_exists() {
+        assert!(!should_warn_relocation(
+            Path::new(XDG),
+            Source::XdgConfigHome,
+            Some(Path::new(LEGACY)),
+            existing(&[XDG, LEGACY]),
+        ));
+    }
+
+    #[test]
+    fn silent_when_cli_arg_given() {
+        assert!(!should_warn_relocation(
+            Path::new("/explicit"),
+            Source::CliArg,
+            Some(Path::new(LEGACY)),
+            existing(&[LEGACY]),
+        ));
+    }
+
+    #[test]
+    fn silent_when_home_default() {
+        assert!(!should_warn_relocation(
+            Path::new(LEGACY),
+            Source::HomeDefault,
+            Some(Path::new(LEGACY)),
+            existing(&[LEGACY]),
+        ));
+    }
+
+    #[test]
+    fn silent_when_home_dir_unknown() {
+        assert!(!should_warn_relocation(
+            Path::new(XDG),
+            Source::XdgConfigHome,
+            None,
+            existing(&[LEGACY]),
+        ));
+    }
+
+    /// `XDG_CONFIG_HOME=$HOME` resolves to the legacy path itself; not a relocation.
+    #[test]
+    fn silent_when_xdg_resolves_to_legacy_path() {
+        assert!(!should_warn_relocation(
+            Path::new(LEGACY),
+            Source::XdgConfigHome,
+            Some(Path::new(LEGACY)),
+            existing(&[LEGACY]),
+        ));
+    }
+}

--- a/proxelar-cli/src/cli.rs
+++ b/proxelar-cli/src/cli.rs
@@ -45,7 +45,8 @@ pub struct Args {
     #[arg(long, default_value_t = 8081)]
     pub gui_port: u16,
 
-    /// Directory for CA certificate and key (default: ~/.proxelar)
+    /// Directory for CA certificate, key, addons, and other proxelar state
+    /// (default: $XDG_CONFIG_HOME/proxelar if set, else ~/.proxelar)
     #[arg(long, value_name = "DIR")]
     pub ca_dir: Option<PathBuf>,
 

--- a/proxelar-cli/src/main.rs
+++ b/proxelar-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod browser;
+mod ca_dir;
 mod cli;
 mod interface;
 mod wireguard_setup;
@@ -32,14 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let ca_dir = args.ca_dir.clone().unwrap_or_else(|| {
-        dirs::home_dir()
-            .unwrap_or_else(|| {
-                tracing::warn!("Could not determine home directory, using current directory");
-                std::path::PathBuf::from(".")
-            })
-            .join(".proxelar")
-    });
+    let ca_dir = ca_dir::resolve_ca_dir(args.ca_dir.clone());
     #[cfg(feature = "scripting")]
     let addons_dir = args
         .addons_dir


### PR DESCRIPTION
## Honor `$XDG_CONFIG_HOME` for `--ca-dir` default

Proxelar hardcoded` ~/.proxelar` as the home for its CA cert/key, addon catalog, browser profile, and WireGuard config. On Linux especially, users who keep their configuration under `$XDG_CONFIG_HOME` had no way to move that state short of passing `--ca-dir` on every invocation.

Resolve the directory with an explicit precedence instead:

  1. `--ca-dir <DIR>`              explicit override, always wins
  2. `$XDG_CONFIG_HOME/proxelar`   when set to a non-empty absolute path
  3. `~/.proxelar `                default when neither applies

The lookup moves out of main() into a new `proxelar-cli/src/ca_dir.rs`. `resolve_ca_dir_from_parts()` takes the env value and home directory as parameters and returns the chosen path plus a Source enum describing which rule produced it, so the precedence is unit-testable without mutating process environment and without the races that `std::env::set_var` causes under a threaded test runner.

Per the XDG base directory spec, `XDG_CONFIG_HOME` is ignored when empty and when relative; a relative value logs a warning rather than silently producing a path resolved against the current working directory.

State is deliberately not migrated between locations. That leaves a trap for existing users: anyone who already exports `XDG_CONFIG_HOME` and has a populated `~/.proxelar` would, on upgrade, silently land on an empty directory, regenerate a CA their browser does not trust, and lose their installed addons and WireGuard peer config with no indication why. Rather than copy files around behind the user's back or special-case the precedence, warn once at startup when all of the following hold: no `--ca-dir` was passed, the XDG rule selected the path, that path does not yet exist, and `~/.proxelar` does. The warning names both directories and gives the exact `--ca-dir` invocation to keep the old state. The decision is a pure predicate over an injected existence check, so all four branches are covered by tests.

Both this notice and the relative-path one are printed to stderr rather than logged through tracing. The subscriber is built from` EnvFilter::from_default_env()`, whose default directive is `ERROR`, so a `tracing::warn!` is invisible unless the user exports `RUST_LOG` - which would have defeated the point of warning at all. Raising the global default instead is not an option here: roughly thirty warn! sites in proxyapi sit on per-request and per-packet paths, and the TUI renders to the same stdout the subscriber writes to. Both notices are emitted from `resolve_ca_dir` before any interface starts, so stderr is safe in every mode.

The Dockerfile documents that the container keeps state at `/root/.proxelar`, matching the declared `VOLUME`; setting `XDG_CONFIG_HOME` or `--ca-di`r moves it, in which case that path should be mounted instead.

Documentation is updated to match. The README and the mdbook CLI reference both spell out the precedence, and `XDG_CONFIG_HOME` is listed in the environment variable table. Prose that previously asserted `~/.proxela`r as fact now refers to "the state directory (`~/.proxelar` by default)" across the CA certificate, CA trust, browser/curl, quick start, WireGuard, and threat model pages. Concrete paths inside copy-pasteable shell commands are left intact, with a callout pointing at the precedence section, since substituting a placeholder there would break copy-paste for the common case. The Docker instructions note that the container always stores state at `/root/.proxelar`, so hosts with a non-default state directory should mount that path instead.

No behavior changes for users who do not set XDG_CONFIG_HOME.

## Changelog
- [x] I have added an entry to `CHANGELOG.md` under `[Unreleased]`, or this PR does not need one

## Tests
- [x] I have added or updated tests for user-visible behavior changes, or this PR does not need tests
