### PR TITLE
fix(tui): render multi-line bodies as separate lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Render multi-line request and response bodies in the TUI as separate rows instead of collapsing them into a single wrapped row.
+
 ## [0.5.1] - 2026-07-31
 
 ### Added

--- a/proxelar-cli/src/interface/tui/ui.rs
+++ b/proxelar-cli/src/interface/tui/ui.rs
@@ -694,7 +694,7 @@ fn build_request_lines(request: &proxyapi_models::ProxiedRequest) -> Vec<Line<'s
                 Style::default().fg(Color::Yellow),
             )));
         }
-        lines.push(Line::from(render_body(request.headers(), request.body())));
+        lines.extend(render_body_lines(request.headers(), request.body()));
     }
 
     lines
@@ -736,20 +736,25 @@ fn build_response_lines(response: &proxyapi_models::ProxiedResponse) -> Vec<Line
                 Style::default().fg(Color::Yellow),
             )));
         }
-        lines.push(Line::from(render_body(response.headers(), response.body())));
+        lines.extend(render_body_lines(response.headers(), response.body()));
     }
 
     lines
 }
 
-fn render_body(headers: &http::HeaderMap, body: &[u8]) -> String {
-    match proxyapi::content::content_view(headers, body) {
+/// One `Line` per source line: a `Line` is a single terminal row, so embedded
+/// newlines in the rendered body would otherwise collapse into one wrapped row.
+fn render_body_lines(headers: &http::HeaderMap, body: &[u8]) -> Vec<Line<'static>> {
+    let text = match proxyapi::content::content_view(headers, body) {
         Ok(view) => view.text,
         Err(error) => format!(
             "[content decoding failed: {error}]\n{}",
             String::from_utf8_lossy(body)
         ),
-    }
+    };
+    text.lines()
+        .map(|line| Line::from(Span::raw(line.to_owned())))
+        .collect()
 }
 
 fn build_frames_lines(
@@ -1397,6 +1402,71 @@ mod tests {
             .join("\n");
         assert!(closed_text.contains("00 01 02 03"));
         assert!(closed_text.contains("Connection closed"));
+    }
+
+    #[test]
+    fn pretty_printed_json_body_spans_multiple_lines() {
+        let res = response(
+            StatusCode::OK,
+            Some("application/json"),
+            Bytes::from_static(b"{\"a\":1,\"b\":[true,null]}"),
+            0,
+        );
+        let lines = build_response_lines(&res);
+
+        // A `Line` is one terminal row, so no row may carry an embedded newline.
+        assert!(lines.iter().all(|line| !line.to_string().contains('\n')));
+
+        let body_rows = lines
+            .iter()
+            .filter(|line| {
+                let text = line.to_string();
+                text.contains("\"a\"") || text.contains("\"b\"")
+            })
+            .count();
+        assert!(body_rows > 1, "pretty-printed body collapsed into one row");
+    }
+
+    #[test]
+    fn plain_text_body_newlines_become_separate_lines() {
+        let res = response(
+            StatusCode::OK,
+            Some("text/plain"),
+            Bytes::from_static(b"first\nsecond\nthird"),
+            0,
+        );
+        let rendered: Vec<String> = build_response_lines(&res)
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+
+        assert!(rendered.iter().any(|line| line == "first"));
+        assert!(rendered.iter().any(|line| line == "second"));
+        assert!(rendered.iter().any(|line| line == "third"));
+    }
+
+    #[test]
+    fn trailing_newline_does_not_add_a_blank_line() {
+        let with_newline = response(
+            StatusCode::OK,
+            Some("text/plain"),
+            Bytes::from_static(b"only\n"),
+            0,
+        );
+        let without_newline = response(
+            StatusCode::OK,
+            Some("text/plain"),
+            Bytes::from_static(b"only"),
+            0,
+        );
+
+        let rendered = build_response_lines(&with_newline);
+        assert_eq!(rendered.len(), build_response_lines(&without_newline).len());
+        assert_eq!(
+            rendered.last().expect("body row").to_string(),
+            "only",
+            "trailing newline produced a blank row"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Render multi-line bodies as separate lines

### Summary

Request/response bodies in the TUI detail view were rendered as a single `Line`, so any embedded newlines (e.g. pretty-printed JSON, multi-line text bodies) collapsed into one wrapped terminal row instead of appearing as separate rows.

`render_body` (returning a `String`) is replaced with `render_body_lines`, which splits the rendered body text on line boundaries and returns one `Line` per source line. `build_request_lines` and `build_response_lines` now `extend` with these lines instead of pushing a single one.

### Testing

Three regression tests were added in `proxelar-cli/src/interface/tui/ui.rs`:
- `pretty_printed_json_body_spans_multiple_lines` — asserts no rendered line contains an embedded `\n`, and that a JSON body spans multiple rows.
- `plain_text_body_newlines_become_separate_lines` — asserts each line of a plain-text body appears as its own row.
- `trailing_newline_does_not_add_a_blank_line` — asserts a trailing newline doesn't produce an extra blank row.

## Changelog
- [x] I have added an entry to `CHANGELOG.md` under `[Unreleased]`, or this PR does not need one

## Tests
- [x] I have added or updated tests for user-visible behavior changes, or this PR does not need tests

## Showcase

### Before
<img width="721" height="728" alt="bettershot_1787561386021" src="https://github.com/user-attachments/assets/c3387f0e-2bae-4ad4-924d-2a7fca500ba0" />

### After
<img width="879" height="1347" alt="bettershot_1787570305122" src="https://github.com/user-attachments/assets/f48fa164-962f-415c-9167-2cf086f76c17" />